### PR TITLE
[CI] Upgrade to actions/cache v4

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,7 +64,7 @@ jobs:
           distribution: 'zulu'
           java-version: 11
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,14 +87,14 @@ jobs:
           name: generated-docs
           path: staging
       - name: Cache Python packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -64,14 +64,14 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install sbt
       - name: Cache SBT
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
           pip install pre-commit
       - name: set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -113,7 +113,7 @@ jobs:
           echo "os-name=$OS_NAME" >> $GITHUB_OUTPUT
       - name: Cache Spark installations
         if: runner.os != 'Windows'
-        uses: actions/cache@master
+        uses: actions/cache@v4
         with:
           path: ~/spark
           key: apache.sedona-apache-spark-${{ steps.os-name.outputs.os-name }}-${{ env.SPARK_VERSION }}

--- a/.github/workflows/snowflake-tester.yml
+++ b/.github/workflows/snowflake-tester.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           java-version: '8'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
We upgrade actions/cache to v4 because actions/cache v2 is deprecated and won't work after Feb 2025. See https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/ for details.