### PR TITLE
[CI] Bump java 11 and geotools 33 in snowflake tester

### DIFF
--- a/.github/workflows/snowflake-tester.yml
+++ b/.github/workflows/snowflake-tester.yml
@@ -36,7 +36,7 @@ env:
   SNOWFLAKE_WAREHOUSE: ${{vars.SNOWFLAKE_WAREHOUSE}}
   SNOWFLAKE_ROLE: ${{vars.SNOWFLAKE_ROLE}}
   SNOWFLAKE_ACCOUNT: ${{vars.SNOWFLAKE_ACCOUNT}}
-  SNOWFLAKE_GEOTOOLS_VERSION: '1.5.1-28.2'
+  SNOWFLAKE_GEOTOOLS_VERSION: '1.8.0-33.1-rc1'
 
 jobs:
   build:
@@ -45,9 +45,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)


## Is this PR related to a ticket?

This is a CI update. The PR name follows the format `[CI] my subject`

## What changes were proposed in this PR?

Bumping to java 11 and geotools 33 to align with Sedona

## How was this patch tested?



## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation.
