### PR TITLE
[GH-2716] Always use native byte order when writing WKBs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['actions', 'cpp', 'java', 'javascript', 'python']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: 'Security'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,9 +19,9 @@ name: CodeQL Analysis
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   actions: read

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Everyone is welcome to join our community events. We have a community office hou
 
 Please join our Discord community!
 
-[![Apache Sedona Community Discord Server](https://dcbadge.vercel.app/api/server/9A3k5dEBsY)](https://discord.gg/9A3k5dEBsY)
+[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/9A3k5dEBsY)](https://discord.gg/9A3k5dEBsY)
 
 * [Apache Sedona@LinkedIn](https://www.linkedin.com/company/apache-sedona)
 * [Apache Sedona@X](https://X.com/ApacheSedona)

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/Accessors.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/Accessors.java
@@ -24,7 +24,7 @@ public class Accessors {
 
   public Accessors() {}
 
-  public boolean S2_isEmpty(S2Geography s2Geography) {
+  public static boolean S2_isEmpty(S2Geography s2Geography) {
     for (int i = 0; i < s2Geography.numShapes(); i++) {
       S2Shape shape = s2Geography.shape(i);
       if (!shape.isEmpty()) return false;
@@ -32,7 +32,7 @@ public class Accessors {
     return true;
   }
 
-  public boolean S2_isCollection(PolygonGeography polygonGeography) {
+  public static boolean S2_isCollection(PolygonGeography polygonGeography) {
     int numOuterLoops = 0;
     for (int i = 0; i < polygonGeography.polygon.numLoops(); i++) {
       S2Loop loop = polygonGeography.polygon.loop(i);
@@ -79,7 +79,7 @@ public class Accessors {
     }
   }
 
-  public int S2_dimension(S2Geography s2Geography) {
+  public static int S2_dimension(S2Geography s2Geography) {
     int dimension = s2Geography.dimension();
     if (dimension != -1) return dimension;
 
@@ -90,7 +90,7 @@ public class Accessors {
     return dimension;
   }
 
-  public int S2_numPoints(S2Geography s2Geography) {
+  public static int S2_numPoints(S2Geography s2Geography) {
     int numPoints = 0;
     for (int i = 0; i < s2Geography.numShapes(); i++) {
       S2Shape shape = s2Geography.shape(i);

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/MultiPolygonGeography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/MultiPolygonGeography.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.S2Polygon;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MultiPolygonGeography extends GeographyCollection {
+  /**
+   * Wrap each raw S2Polygon in a PolygonGeography, then hand it off to GeographyCollection to do
+   * the rest (including serialization).
+   */
+  public MultiPolygonGeography(List<S2Polygon> polygons) {
+    super(
+        polygons.stream()
+            .map(PolygonGeography::new) // wrap each S2Polygon
+            .collect(Collectors.toList())); // into a List<PolygonGeography>
+    if (polygons.isEmpty()) {
+      new MultiPolygonGeography();
+    }
+  }
+
+  public MultiPolygonGeography() {
+    super(Collections.emptyList());
+  }
+
+  public List<S2Geography> getFeatures() {
+    return features;
+  }
+
+  @Override
+  public int dimension() {
+    // every child PolygonGeography
+    return 2;
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/PointGeography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/PointGeography.java
@@ -27,6 +27,9 @@ import com.google.common.geometry.PrimitiveArrays.Bytes;
 import java.io.*;
 import java.util.*;
 import java.util.List;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +70,7 @@ public class PointGeography extends S2Geography {
 
   @Override
   public int numShapes() {
-    return points.isEmpty() ? 0 : 1;
+    return points.size();
   }
 
   @Override
@@ -238,5 +241,19 @@ public class PointGeography extends S2Geography {
 
     geo.points.addAll(pts);
     return geo;
+  }
+
+  public CoordinateSequence getCoordinateSequence() {
+    List<S2Point> pts = getPoints();
+    Coordinate[] coordArray = new Coordinate[pts.size()];
+    for (int i = 0; i < pts.size(); i++) {
+      S2Point pt = pts.get(i);
+      S2LatLng ll = new S2LatLng(pt);
+      double lat = ll.latDegrees();
+      double lon = ll.lngDegrees();
+      Coordinate c = new Coordinate(lon, lat);
+      coordArray[i] = c;
+    }
+    return new CoordinateArraySequence(coordArray);
   }
 }

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/PolylineGeography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/PolylineGeography.java
@@ -28,6 +28,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 
 /** A Geography representing zero or more polylines using S2Polyline. */
 public class PolylineGeography extends S2Geography {
@@ -140,5 +143,31 @@ public class PolylineGeography extends S2Geography {
       geo.polylines.add(pl);
     }
     return geo;
+  }
+
+  public CoordinateSequence getCoordinateSequence() {
+    // 1) Count total vertices across all polylines
+    int totalVerts = 0;
+    for (S2Polyline pl : polylines) {
+      totalVerts += pl.numVertices();
+    }
+
+    // 2) Build a flat array of JTS Coordinates
+    Coordinate[] coords = new Coordinate[totalVerts];
+    int idx = 0;
+    for (S2Polyline pl : polylines) {
+      int n = pl.numVertices();
+      for (int i = 0; i < n; i++, idx++) {
+        S2Point pt = pl.vertex(i);
+        S2LatLng ll = new S2LatLng(pt);
+        double lat = ll.latDegrees();
+        double lon = ll.lngDegrees();
+        Coordinate c = new Coordinate(lon, lat);
+        coords[idx] = c;
+      }
+    }
+
+    // 3) Wrap in a CoordinateArraySequence
+    return new CoordinateArraySequence(coords);
   }
 }

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/S2Geography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/S2Geography.java
@@ -42,6 +42,12 @@ public abstract class S2Geography {
     this.kind = kind;
   }
 
+  public void setSRID(int srid) {}
+
+  public int getSRID() {
+    return -1;
+  }
+
   public enum GeographyKind {
     UNINITIALIZED(0),
     POINT(1),

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/SinglePointGeography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/SinglePointGeography.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.S2Point;
+
+public class SinglePointGeography extends PointGeography {
+  public SinglePointGeography(S2Point p) {
+    super(p);
+  }
+
+  public SinglePointGeography() {
+    super();
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/SinglePolylineGeography.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/SinglePolylineGeography.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.S2Polyline;
+
+public class SinglePolylineGeography extends PolylineGeography {
+  public SinglePolylineGeography(S2Polyline p) {
+    super(p);
+  }
+
+  public SinglePolylineGeography() {
+    super();
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/WKBReader.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/WKBReader.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+import com.google.common.geometry.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.*;
+
+/** This code is a custom modified version of JTS WKBReader */
+public class WKBReader {
+  /**
+   * Converts a hexadecimal string to a byte array. The hexadecimal digit symbols are
+   * case-insensitive.
+   *
+   * @param hex a string containing hex digits
+   * @return an array of bytes with the value of the hex string
+   */
+  public static byte[] hexToBytes(String hex) {
+    int byteLen = hex.length() / 2;
+    byte[] bytes = new byte[byteLen];
+
+    for (int i = 0; i < hex.length() / 2; i++) {
+      int i2 = 2 * i;
+      if (i2 + 1 > hex.length()) throw new IllegalArgumentException("Hex string has odd length");
+
+      int nib1 = hexToInt(hex.charAt(i2));
+      int nib0 = hexToInt(hex.charAt(i2 + 1));
+      byte b = (byte) ((nib1 << 4) + (byte) nib0);
+      bytes[i] = b;
+    }
+    return bytes;
+  }
+
+  private static int hexToInt(char hex) {
+    int nib = Character.digit(hex, 16);
+    if (nib < 0) throw new IllegalArgumentException("Invalid hex digit: '" + hex + "'");
+    return nib;
+  }
+
+  private static final String INVALID_GEOM_TYPE_MSG = "Invalid geometry type encountered in ";
+
+  private static final String FIELD_NUMCOORDS = "numCoords";
+
+  private static final String FIELD_NUMRINGS = "numRings";
+
+  private static final String FIELD_NUMELEMS = "numElems";
+
+  private GeometryFactory factory;
+  private CoordinateSequenceFactory csFactory;
+  private PrecisionModel precisionModel;
+  // default dimension - will be set on read
+  private int inputDimension = 2;
+  /**
+   * true if structurally invalid input should be reported rather than repaired. At some point this
+   * could be made client-controllable.
+   */
+  private boolean isStrict = false;
+
+  private ByteOrderDataInStream dis = new ByteOrderDataInStream();
+  private double[] ordValues;
+
+  private int maxNumFieldValue;
+
+  /** Default constructor uses a JTS Array-based sequence factory. */
+  public WKBReader() {
+    this(new GeometryFactory());
+  }
+
+  public WKBReader(GeometryFactory geometryFactory) {
+    this.factory = geometryFactory;
+    precisionModel = factory.getPrecisionModel();
+    csFactory = factory.getCoordinateSequenceFactory();
+  }
+
+  /**
+   * Reads a single {@link S2Geography} in WKB format from a byte array.
+   *
+   * @param bytes the byte array to read from
+   * @return the geometry read
+   * @throws ParseException if the WKB is ill-formed
+   */
+  public S2Geography read(byte[] bytes) throws ParseException {
+    try {
+      // Use a very high limit to avoid malformed input OOM
+      return read(new ByteArrayInStream(bytes), Integer.MAX_VALUE);
+    } catch (IOException ex) {
+      throw new RuntimeException("I/O error reading WKB: " + ex.getMessage(), ex);
+    }
+  }
+
+  /**
+   * Reads a {@link S2Geography} in binary WKB format from an {@link InStream}.
+   *
+   * @param is the stream to read from
+   * @return the Geometry read
+   * @throws IOException if the underlying stream creates an error
+   * @throws ParseException if the WKB is ill-formed
+   */
+  public S2Geography read(InStream is) throws IOException, ParseException {
+    // can't tell size of InStream, but MAX_VALUE should be safe
+    return read(is, Integer.MAX_VALUE);
+  }
+
+  private S2Geography read(InStream is, int maxCoordNum) throws IOException, ParseException {
+    /**
+     * This puts an upper bound on the allowed value in coordNum fields. It avoids OOM exceptions
+     * due to malformed input.
+     */
+    this.maxNumFieldValue = maxCoordNum;
+    dis.setInStream(is);
+    return readGeometry(0);
+  }
+
+  private int readNumField(String fieldName) throws IOException, ParseException {
+    // num field is unsigned int, but Java has only signed int
+    int num = dis.readInt();
+    if (num < 0 || num > maxNumFieldValue) {
+      throw new ParseException(fieldName + " value is too large");
+    }
+    return num;
+  }
+
+  private S2Geography readGeometry(int SRID) throws IOException, ParseException {
+
+    // determine byte order
+    byte byteOrderWKB = dis.readByte();
+
+    // always set byte order, since it may change from geometry to geometry
+    if (byteOrderWKB == WKBConstants.wkbNDR) {
+      dis.setOrder(ByteOrderValues.LITTLE_ENDIAN);
+    } else if (byteOrderWKB == WKBConstants.wkbXDR) {
+      dis.setOrder(ByteOrderValues.BIG_ENDIAN);
+    } else if (isStrict) {
+      throw new ParseException("Unknown geometry byte order (not NDR or XDR): " + byteOrderWKB);
+    }
+    // if not strict and not XDR or NDR, then we just use the dis default set at the
+    // start of the geometry (if a multi-geometry).  This  allows WBKReader to work
+    // with Spatialite native BLOB WKB, as well as other WKB variants that might just
+    // specify endian-ness at the start of the multigeometry.
+
+    int typeInt = dis.readInt();
+
+    /**
+     * To get geometry type mask out EWKB flag bits, and use only low 3 digits of type word. This
+     * supports both EWKB and ISO/OGC.
+     */
+    int geometryType = (typeInt & 0xffff) % 1000;
+
+    // handle 3D and 4D WKB geometries
+    // geometries with Z coordinates have the 0x80 flag (postgis EWKB)
+    // or are in the 1000 range (Z) or in the 3000 range (ZM) of geometry type (ISO/OGC 06-103r4)
+    boolean hasZ =
+        ((typeInt & 0x80000000) != 0
+            || (typeInt & 0xffff) / 1000 == 1
+            || (typeInt & 0xffff) / 1000 == 3);
+    // geometries with M coordinates have the 0x40 flag (postgis EWKB)
+    // or are in the 1000 range (M) or in the 3000 range (ZM) of geometry type (ISO/OGC 06-103r4)
+    boolean hasM =
+        ((typeInt & 0x40000000) != 0
+            || (typeInt & 0xffff) / 1000 == 2
+            || (typeInt & 0xffff) / 1000 == 3);
+    // System.out.println(typeInt + " - " + geometryType + " - hasZ:" + hasZ);
+    inputDimension = 2 + (hasZ ? 1 : 0) + (hasM ? 1 : 0);
+
+    EnumSet<Ordinate> ordinateFlags = EnumSet.of(Ordinate.X, Ordinate.Y);
+    if (hasZ) {
+      ordinateFlags.add(Ordinate.Z);
+    }
+    if (hasM) {
+      ordinateFlags.add(Ordinate.M);
+    }
+
+    // determine if SRIDs are present (EWKB only)
+    boolean hasSRID = (typeInt & 0x20000000) != 0;
+    if (hasSRID) {
+      SRID = dis.readInt();
+    }
+
+    // only allocate ordValues buffer if necessary
+    if (ordValues == null || ordValues.length < inputDimension)
+      ordValues = new double[inputDimension];
+
+    S2Geography geog = null;
+    switch (geometryType) {
+      case WKBConstants.wkbPoint:
+        geog = readPoint(ordinateFlags);
+        break;
+      case WKBConstants.wkbLineString:
+        geog = readPolyline(ordinateFlags);
+        break;
+      case WKBConstants.wkbPolygon:
+        geog = readPolygon(ordinateFlags);
+        break;
+      case WKBConstants.wkbMultiPoint:
+        geog = readMultiPoint(SRID);
+        break;
+      case WKBConstants.wkbMultiLineString:
+        geog = readMultiPolyline(SRID);
+        break;
+      case WKBConstants.wkbMultiPolygon:
+        geog = readMultiPolygon(SRID);
+        break;
+      case WKBConstants.wkbGeometryCollection:
+        geog = readGeographyCollection(SRID);
+        break;
+      default:
+        throw new ParseException("Unknown WKB type " + geometryType);
+    }
+    setSRID(geog, SRID);
+    return geog;
+  }
+
+  /**
+   * Sets the SRID, if it was specified in the WKB
+   *
+   * @param g the geometry to update
+   * @return the geometry with an updated SRID value, if required
+   */
+  private S2Geography setSRID(S2Geography g, int SRID) {
+    if (SRID != 0) g.setSRID(SRID);
+    return g;
+  }
+
+  private SinglePointGeography readPoint(EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence pts = readCoordinateSequence(1, ordinateFlags);
+    // If X and Y are NaN create a empty point
+    if (pts.size() <= 0 || Double.isNaN(pts.getX(0)) || Double.isNaN(pts.getY(0))) {
+      return new SinglePointGeography();
+    }
+    double lon = pts.getX(0);
+    double lat = pts.getY(0);
+    S2Point s2Point = S2LatLng.fromDegrees(lat, lon).toPoint();
+
+    // Build via S2Builder + S2PointVectorLayer
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PointVectorLayer layer = new S2PointVectorLayer();
+    builder.startLayer(layer);
+    builder.addPoint(s2Point);
+
+    // must call build() before reading out the points
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("Failed to build S2 point layer: " + error.text());
+    }
+    // Extract the resulting points
+    List<S2Point> points = layer.getPointVector();
+    if (points.isEmpty()) {
+      return new SinglePointGeography();
+    }
+    return new SinglePointGeography(points.get(0));
+  }
+
+  private SinglePolylineGeography readPolyline(EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    int size = readNumField(FIELD_NUMCOORDS);
+    CoordinateSequence seq = readCoordinateSequenceLineString(size, ordinateFlags);
+    if (seq.size() < 2) {
+      // empty or extended-but-all-NaN → empty geography
+      return new SinglePolylineGeography();
+    }
+
+    List<S2Point> pts = new ArrayList<>(seq.size());
+    for (int i = 0; i < seq.size(); i++) {
+      double lon = seq.getX(i);
+      double lat = seq.getY(i);
+      pts.add(S2LatLng.fromDegrees(lat, lon).toPoint());
+    }
+
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PolylineLayer layer = new S2PolylineLayer();
+    builder.startLayer(layer);
+
+    builder.addPolyline(new S2Polyline(pts));
+
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("Failed to build S2 polyline: " + error.text());
+    }
+    S2Polyline s2poly = layer.getPolyline();
+    return new SinglePolylineGeography(s2poly);
+  }
+
+  private PolygonGeography readPolygon(EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    int numRings = readNumField(FIELD_NUMRINGS);
+    if (numRings <= 0) {
+      return new PolygonGeography();
+    }
+
+    List<S2Loop> loops = new ArrayList<>(numRings);
+    for (int r = 0; r < numRings; r++) {
+      int coordCount = readNumField(FIELD_NUMCOORDS);
+      CoordinateSequence seq = readCoordinateSequenceRing(coordCount, ordinateFlags);
+      // build the loop
+      List<S2Point> pts = new ArrayList<>(seq.size());
+      for (int i = 0; i < seq.size(); i++) {
+        pts.add(S2LatLng.fromDegrees(seq.getY(i), seq.getX(i)).toPoint());
+      }
+      loops.add(new S2Loop(pts));
+    }
+    if (loops.isEmpty()) {
+      return new PolygonGeography();
+    }
+
+    // Now feed those loops into S2Builder + S2PolygonLayer:
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PolygonLayer polyLayer = new S2PolygonLayer();
+    builder.startLayer(polyLayer);
+
+    // add shell + holes
+    for (S2Loop loop : loops) {
+      builder.addLoop(loop);
+    }
+
+    // build
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("S2Builder failed: " + error.text());
+    }
+
+    // extract the stitched polygon
+    S2Polygon s2poly = polyLayer.getPolygon();
+
+    // wrap in your PolygonGeography
+    return new PolygonGeography(s2poly);
+  }
+
+  private PointGeography readMultiPoint(int SRID) throws IOException, ParseException {
+    int numGeom = readNumField(FIELD_NUMELEMS);
+    List<S2Point> pts = new ArrayList<>(numGeom);
+    for (int i = 0; i < numGeom; i++) {
+      S2Geography point = readGeometry(SRID);
+      if (!(point instanceof PointGeography)) {
+        throw new ParseException(INVALID_GEOM_TYPE_MSG + "MultiPoint");
+      }
+      pts.addAll(((PointGeography) point).getPoints());
+    }
+    return new PointGeography(pts);
+  }
+
+  private PolylineGeography readMultiPolyline(int SRID) throws IOException, ParseException {
+    int numGeom = readNumField(FIELD_NUMELEMS);
+    List<S2Polyline> polylines = new ArrayList<>(numGeom);
+    for (int i = 0; i < numGeom; i++) {
+      S2Geography polyline = readGeometry(SRID);
+      if (!(polyline instanceof PolylineGeography)) {
+        throw new ParseException(INVALID_GEOM_TYPE_MSG + "MultiPolyline");
+      }
+      polylines.addAll(((PolylineGeography) polyline).getPolylines());
+    }
+    return new PolylineGeography(polylines);
+  }
+
+  private MultiPolygonGeography readMultiPolygon(int SRID) throws IOException, ParseException {
+    int numGeom = readNumField(FIELD_NUMELEMS);
+    List<S2Polygon> polygons = new ArrayList<>(numGeom);
+    for (int i = 0; i < numGeom; i++) {
+      S2Geography geom = readGeometry(SRID);
+      polygons.add(((PolygonGeography) geom).polygon);
+    }
+    return new MultiPolygonGeography(polygons);
+  }
+
+  private GeographyCollection readGeographyCollection(int SRID) throws IOException, ParseException {
+    int numGeom = readNumField(FIELD_NUMELEMS);
+    S2Geography[] geoms = new S2Geography[numGeom];
+    for (int i = 0; i < numGeom; i++) {
+      geoms[i] = readGeometry(SRID);
+    }
+    return new GeographyCollection(List.of(geoms));
+  }
+
+  private CoordinateSequence readCoordinateSequence(int size, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence seq =
+        csFactory.create(size, inputDimension, ordinateFlags.contains(Ordinate.M) ? 1 : 0);
+    int targetDim = seq.getDimension();
+    if (targetDim > inputDimension) targetDim = inputDimension;
+    for (int i = 0; i < size; i++) {
+      readCoordinate();
+      for (int j = 0; j < targetDim; j++) {
+        seq.setOrdinate(i, j, ordValues[j]);
+      }
+    }
+    return seq;
+  }
+
+  private CoordinateSequence readCoordinateSequenceLineString(
+      int size, EnumSet<Ordinate> ordinateFlags) throws IOException, ParseException {
+    CoordinateSequence seq = readCoordinateSequence(size, ordinateFlags);
+    if (isStrict) return seq;
+    if (seq.size() == 0 || seq.size() >= 2) return seq;
+    return CoordinateSequences.extend(csFactory, seq, 2);
+  }
+
+  private CoordinateSequence readCoordinateSequenceRing(int size, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence seq = readCoordinateSequence(size, ordinateFlags);
+    if (isStrict) return seq;
+    if (CoordinateSequences.isRing(seq)) return seq;
+    return CoordinateSequences.ensureValidRing(csFactory, seq);
+  }
+
+  /**
+   * Reads a coordinate value with the specified dimensionality. Makes the X and Y ordinates precise
+   * according to the precision model in use.
+   *
+   * @throws ParseException
+   */
+  private void readCoordinate() throws IOException, ParseException {
+    for (int i = 0; i < inputDimension; i++) {
+      if (i <= 1) {
+        try {
+          double v = dis.readDouble();
+          ordValues[i] = precisionModel.makePrecise(v);
+        } catch (ParseException pe) {
+          return;
+        }
+      } else {
+        ordValues[i] = dis.readDouble();
+      }
+    }
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/WKBWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/WKBWriter.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.*;
+
+public class WKBWriter {
+  /** A custom modified version based on JTS WKBWriter */
+  /**
+   * Converts a byte array to a hexadecimal string.
+   *
+   * @param bytes
+   * @return a string of hexadecimal digits
+   * @deprecated
+   */
+  public static String bytesToHex(byte[] bytes) {
+    return toHex(bytes);
+  }
+
+  /**
+   * Converts a byte array to a hexadecimal string.
+   *
+   * @param bytes a byte array
+   * @return a string of hexadecimal digits
+   */
+  public static String toHex(byte[] bytes) {
+    StringBuffer buf = new StringBuffer();
+    for (int i = 0; i < bytes.length; i++) {
+      byte b = bytes[i];
+      buf.append(toHexDigit((b >> 4) & 0x0F));
+      buf.append(toHexDigit(b & 0x0F));
+    }
+    return buf.toString();
+  }
+
+  private static char toHexDigit(int n) {
+    if (n < 0 || n > 15) throw new IllegalArgumentException("Nibble value out of range: " + n);
+    if (n <= 9) return (char) ('0' + n);
+    return (char) ('A' + (n - 10));
+  }
+
+  private EnumSet<Ordinate> outputOrdinates;
+  private int outputDimension = 2;
+  private int byteOrder;
+  private boolean includeSRID = false;
+  private ByteArrayOutputStream byteArrayOS = new ByteArrayOutputStream();
+  private OutStream byteArrayOutStream = new OutputStreamOutStream(byteArrayOS);
+  // holds output data values
+  private byte[] buf = new byte[8];
+
+  /**
+   * Creates a writer that writes {@link Geometry}s with output dimension = 2 and BIG_ENDIAN byte
+   * order
+   */
+  public WKBWriter() {
+    this(2, ByteOrderValues.BIG_ENDIAN);
+  }
+
+  /**
+   * Creates a writer that writes {@link Geometry}s with the given dimension (2 or 3) for output
+   * coordinates and {@link ByteOrderValues#BIG_ENDIAN} byte order. If the input geometry has a
+   * small coordinate dimension, coordinates will be padded with {@link Coordinate#NULL_ORDINATE}.
+   *
+   * @param outputDimension the coordinate dimension to output (2 or 3)
+   */
+  public WKBWriter(int outputDimension) {
+    this(outputDimension, ByteOrderValues.BIG_ENDIAN);
+  }
+
+  public WKBWriter(int outputDimension, boolean includeSRID) {
+    this(outputDimension, ByteOrderValues.BIG_ENDIAN, includeSRID);
+  }
+
+  public WKBWriter(int outputDimension, int byteOrder) {
+    this(outputDimension, byteOrder, false);
+  }
+
+  public WKBWriter(int outputDimension, int byteOrder, boolean includeSRID) {
+    this.outputDimension = outputDimension;
+    this.byteOrder = byteOrder;
+    this.includeSRID = includeSRID;
+
+    if (outputDimension < 2 || outputDimension > 4)
+      throw new IllegalArgumentException("Output dimension must be 2 to 4");
+
+    this.outputOrdinates = EnumSet.of(Ordinate.X, Ordinate.Y);
+    if (outputDimension > 2) outputOrdinates.add(Ordinate.Z);
+    if (outputDimension > 3) outputOrdinates.add(Ordinate.M);
+  }
+
+  /**
+   * Sets the {@link Ordinate} that are to be written. Possible members are:
+   *
+   * <ul>
+   *   <li>{@link Ordinate#X}
+   *   <li>{@link Ordinate#Y}
+   *   <li>{@link Ordinate#Z}
+   *   <li>{@link Ordinate#M}
+   * </ul>
+   *
+   * Values of {@link Ordinate#X} and {@link Ordinate#Y} are always assumed and not particularly
+   * checked for.
+   *
+   * @param outputOrdinates A set of {@link Ordinate} values
+   */
+  public void setOutputOrdinates(EnumSet<Ordinate> outputOrdinates) {
+
+    this.outputOrdinates.remove(Ordinate.Z);
+    this.outputOrdinates.remove(Ordinate.M);
+
+    if (this.outputDimension == 3) {
+      if (outputOrdinates.contains(Ordinate.Z)) this.outputOrdinates.add(Ordinate.Z);
+      else if (outputOrdinates.contains(Ordinate.M)) this.outputOrdinates.add(Ordinate.M);
+    }
+    if (this.outputDimension == 4) {
+      if (outputOrdinates.contains(Ordinate.Z)) this.outputOrdinates.add(Ordinate.Z);
+      if (outputOrdinates.contains(Ordinate.M)) this.outputOrdinates.add(Ordinate.M);
+    }
+  }
+
+  /**
+   * Gets a bit-pattern defining which ordinates should be
+   *
+   * @return an ordinate bit-pattern
+   * @see #setOutputOrdinates(EnumSet)
+   */
+  public EnumSet<Ordinate> getOutputOrdinates() {
+    return this.outputOrdinates;
+  }
+
+  /**
+   * Writes a {@link S2Geography} into a byte array.
+   *
+   * @param geog the geometry to write
+   * @return the byte array containing the WKB
+   */
+  public byte[] write(S2Geography geog) {
+    try {
+      byteArrayOS.reset();
+      write(geog, byteArrayOutStream);
+    } catch (IOException ex) {
+      throw new RuntimeException("Unexpected IO exception: " + ex.getMessage());
+    }
+    return byteArrayOS.toByteArray();
+  }
+
+  /**
+   * Writes a {@link S2Geography} to an {@link OutStream}.
+   *
+   * @param geog the geometry to write
+   * @param os the out stream to write to
+   * @throws IOException if an I/O error occurs
+   */
+  public void write(S2Geography geog, OutStream os) throws IOException {
+    if (geog instanceof SinglePointGeography) {
+      writePoint(WKBConstants.wkbPoint, (SinglePointGeography) geog, os);
+    } else if (geog instanceof PointGeography) {
+      writeMultiPoint(WKBConstants.wkbMultiPoint, (PointGeography) geog, os);
+    } else if (geog instanceof SinglePolylineGeography) {
+      writePolyline(WKBConstants.wkbLineString, (SinglePolylineGeography) geog, os);
+    } else if (geog instanceof PolylineGeography) {
+      writeMultiPolyline(WKBConstants.wkbMultiLineString, (PolylineGeography) geog, os);
+    } else if (geog instanceof PolygonGeography) {
+      writePolygon(WKBConstants.wkbPolygon, (PolygonGeography) geog, os);
+    } else if (geog instanceof MultiPolygonGeography) {
+      writeMultiPolygon(WKBConstants.wkbMultiPolygon, (MultiPolygonGeography) geog, os);
+    } else if (geog instanceof GeographyCollection) {
+      writeGeographyCollection(WKBConstants.wkbGeometryCollection, (GeographyCollection) geog, os);
+    }
+  }
+
+  private void writePoint(int geometryType, SinglePointGeography pt, OutStream os)
+      throws IOException {
+    writeByteOrder(os);
+    writeGeometryType(geometryType, pt, os);
+    if (pt.numShapes() == 0) {
+      writeNaNs(outputDimension, os);
+    } else {
+      S2Point p = pt.getPoints().get(0);
+      S2LatLng ll = new S2LatLng(p);
+
+      double lon = ll.lngDegrees();
+      double lat = ll.latDegrees();
+
+      ByteOrderValues.putDouble(lon, buf, byteOrder);
+      os.write(buf, 8);
+      ByteOrderValues.putDouble(lat, buf, byteOrder);
+      os.write(buf, 8);
+    }
+  }
+
+  private void writeMultiPoint(int geometryType, PointGeography mp, OutStream os)
+      throws IOException {
+    // 1) write the outer MultiPoint header
+    writeByteOrder(os);
+    writeGeometryType(WKBConstants.wkbMultiPoint, mp, os);
+    writeInt(mp.numShapes(), os); // count = number of points
+
+    // 2) temporarily disable SRID on the nested shapes
+    boolean oldIncludeSRID = this.includeSRID;
+    this.includeSRID = false;
+
+    // 3) for each point, write a proper Point WKB
+    for (int i = 0; i < mp.numShapes(); i++) {
+      S2Point p = mp.getPoints().get(i);
+      S2LatLng ll = new S2LatLng(p);
+      double lon = ll.lngDegrees();
+      double lat = ll.latDegrees();
+
+      // nested Point header
+      writeByteOrder(os);
+      writeGeometryType(WKBConstants.wkbPoint, mp, os);
+
+      // coords
+      ByteOrderValues.putDouble(lon, buf, byteOrder);
+      os.write(buf, 8);
+      ByteOrderValues.putDouble(lat, buf, byteOrder);
+      os.write(buf, 8);
+    }
+
+    // 4) restore SRID flag
+    this.includeSRID = oldIncludeSRID;
+  }
+
+  private void writePolyline(int geometryType, SinglePolylineGeography polyline, OutStream os)
+      throws IOException {
+    writeByteOrder(os);
+    writeGeometryType(geometryType, polyline, os);
+    List<S2Polyline> s2line = polyline.getPolylines();
+    for (S2Polyline s2 : s2line) {
+      List<S2Point> verts = s2.vertices();
+      writeInt(verts.size(), os);
+      for (S2Point p : verts) {
+        // round to 6 decimal places
+        S2LatLng ll = new S2LatLng(p);
+        double lon = ll.lngDegrees();
+        double lat = ll.latDegrees();
+
+        ByteOrderValues.putDouble(lon, buf, byteOrder);
+        os.write(buf, 8);
+        ByteOrderValues.putDouble(lat, buf, byteOrder);
+        os.write(buf, 8);
+      }
+    }
+  }
+
+  private void writeMultiPolyline(int geometryType, PolylineGeography polyline, OutStream os)
+      throws IOException {
+    // 1) Outer MultiLineString header
+    writeByteOrder(os);
+    writeGeometryType(WKBConstants.wkbMultiLineString, polyline, os);
+
+    List<S2Polyline> lines = polyline.getPolylines();
+    // 2) Write the number of LineStrings
+    writeInt(lines.size(), os);
+
+    // Temporarily disable SRID on nested shapes
+    boolean oldIncludeSRID = this.includeSRID;
+    this.includeSRID = false;
+
+    // 3) For each LineString:
+    for (S2Polyline s2line : lines) {
+      List<S2Point> verts = s2line.vertices();
+
+      // 3a) Nested LineString header
+      writeByteOrder(os);
+      writeGeometryType(WKBConstants.wkbLineString, polyline, os);
+
+      // 3b) Vertex count
+      writeInt(verts.size(), os);
+
+      // 3c) Coordinates
+      for (S2Point p : verts) {
+        S2LatLng ll = new S2LatLng(p);
+        double lon = ll.lngDegrees();
+        double lat = ll.latDegrees();
+
+        ByteOrderValues.putDouble(lon, buf, byteOrder);
+        os.write(buf, 8);
+        ByteOrderValues.putDouble(lat, buf, byteOrder);
+        os.write(buf, 8);
+      }
+    }
+
+    // 4) Restore SRID flag
+    this.includeSRID = oldIncludeSRID;
+  }
+
+  private void writePolygon(int geometryType, PolygonGeography poly, OutStream os)
+      throws IOException {
+    writeByteOrder(os);
+    writeGeometryType(geometryType, poly, os);
+    S2Polygon s2poly = poly.polygon;
+    List<S2Loop> loops = s2poly.getLoops();
+    writeInt(loops.size(), os);
+    for (S2Loop loop : loops) {
+      int n = loop.numVertices();
+      writeInt(n, os);
+      for (int i = 0; i < n; i++) {
+        S2LatLng ll = new S2LatLng(loop.vertex(i));
+        double lon = ll.lngDegrees();
+        double lat = ll.latDegrees();
+
+        ByteOrderValues.putDouble(lon, buf, byteOrder);
+        os.write(buf, 8);
+        ByteOrderValues.putDouble(lat, buf, byteOrder);
+        os.write(buf, 8);
+      }
+    }
+  }
+
+  private void writeMultiPolygon(int geometryType, MultiPolygonGeography multiPoly, OutStream os)
+      throws IOException {
+    // 1) Outer MultiPolygon header
+    writeByteOrder(os);
+    writeGeometryType(WKBConstants.wkbMultiPolygon, multiPoly, os);
+
+    // 2) Number of polygons
+    List<S2Geography> polys = multiPoly.getFeatures(); // however you expose each sub-polygon
+    writeInt(polys.size(), os);
+
+    // 3) Disable SRID on nested shapes if you include SRID in the outer header
+    boolean oldIncludeSRID = this.includeSRID;
+    this.includeSRID = false;
+
+    // 4) For each polygon, write a full Polygon WKB
+    for (S2Geography pg : polys) {
+      // 4a) Nested Polygon header
+      writeByteOrder(os);
+      writeGeometryType(WKBConstants.wkbPolygon, pg, os);
+
+      // 4b) Number of rings
+      PolygonGeography s2poly = (PolygonGeography) pg;
+      List<S2Loop> loops = s2poly.polygon.getLoops();
+      writeInt(loops.size(), os);
+
+      // 4c) For each ring, write vertex count + coords
+      for (S2Loop loop : loops) {
+        int n = loop.numVertices();
+        writeInt(n, os);
+        for (int i = 0; i < n; i++) {
+          S2LatLng ll = new S2LatLng(loop.vertex(i));
+          double lon = ll.lngDegrees();
+          double lat = ll.latDegrees();
+
+          // X (lon) then Y (lat)—matches Point/LineString ordering
+          ByteOrderValues.putDouble(lon, buf, byteOrder);
+          os.write(buf, 8);
+          ByteOrderValues.putDouble(lat, buf, byteOrder);
+          os.write(buf, 8);
+        }
+      }
+    }
+
+    // 5) Restore SRID flag
+    this.includeSRID = oldIncludeSRID;
+  }
+
+  private void writeGeographyCollection(int geometryType, GeographyCollection gc, OutStream os)
+      throws IOException {
+    writeByteOrder(os);
+    writeGeometryType(geometryType, gc, os);
+    writeInt(gc.numShapes(), os);
+    boolean originalIncludeSRID = this.includeSRID;
+    this.includeSRID = false;
+    for (int i = 0; i < gc.numShapes(); i++) {
+      write(gc.getFeatures().get(i), os);
+    }
+    this.includeSRID = originalIncludeSRID;
+  }
+
+  private void writeByteOrder(OutStream os) throws IOException {
+    if (byteOrder == ByteOrderValues.LITTLE_ENDIAN) buf[0] = WKBConstants.wkbNDR;
+    else buf[0] = WKBConstants.wkbXDR;
+    os.write(buf, 1);
+  }
+
+  private void writeGeometryType(int geometryType, S2Geography g, OutStream os) throws IOException {
+    int ordinals = 0;
+    if (outputOrdinates.contains(Ordinate.Z)) {
+      ordinals = ordinals | 0x80000000;
+    }
+
+    if (outputOrdinates.contains(Ordinate.M)) {
+      ordinals = ordinals | 0x40000000;
+    }
+
+    int flag3D = (outputDimension > 2) ? ordinals : 0;
+    int typeInt = geometryType | flag3D;
+    typeInt |= includeSRID ? 0x20000000 : 0;
+    writeInt(typeInt, os);
+    if (includeSRID) {
+      writeInt(g.getSRID(), os);
+    }
+  }
+
+  private void writeInt(int intValue, OutStream os) throws IOException {
+    ByteOrderValues.putInt(intValue, buf, byteOrder);
+    os.write(buf, 4);
+  }
+
+  private void writeCoordinateSequence(CoordinateSequence seq, boolean writeSize, OutStream os)
+      throws IOException {
+    if (writeSize) writeInt(seq.size(), os);
+
+    for (int i = 0; i < seq.size(); i++) {
+      writeCoordinate(seq, i, os);
+    }
+  }
+
+  private void writeCoordinate(CoordinateSequence seq, int index, OutStream os) throws IOException {
+    ByteOrderValues.putDouble(seq.getX(index), buf, byteOrder);
+    os.write(buf, 8);
+    ByteOrderValues.putDouble(seq.getY(index), buf, byteOrder);
+    os.write(buf, 8);
+
+    // only write 3rd dim if caller has requested it for this writer
+    if (outputDimension >= 3) {
+      // if 3rd dim is requested, only write it if the CoordinateSequence provides it
+      double ordVal = seq.getOrdinate(index, 2);
+      ByteOrderValues.putDouble(ordVal, buf, byteOrder);
+      os.write(buf, 8);
+    }
+    // only write 4th dim if caller has requested it for this writer
+    if (outputDimension == 4) {
+      // if 4th dim is requested, only write it if the CoordinateSequence provides it
+      double ordVal = seq.getOrdinate(index, 3);
+      ByteOrderValues.putDouble(ordVal, buf, byteOrder);
+      os.write(buf, 8);
+    }
+  }
+
+  private void writeNaNs(int numNaNs, OutStream os) throws IOException {
+    for (int i = 0; i < numNaNs; i++) {
+      ByteOrderValues.putDouble(Double.NaN, buf, byteOrder);
+      os.write(buf, 8);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/WKTReader.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/WKTReader.java
@@ -1,0 +1,929 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StreamTokenizer;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.io.Ordinate;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTConstants;
+import org.locationtech.jts.util.Assert;
+
+public class WKTReader {
+  private static final String COMMA = ",";
+  private static final String L_PAREN = "(";
+  private static final String R_PAREN = ")";
+  private static final String NAN_SYMBOL = "NaN";
+
+  private GeometryFactory geometryFactory;
+  private CoordinateSequenceFactory csFactory;
+  private static CoordinateSequenceFactory csFactoryXYZM =
+      CoordinateArraySequenceFactory.instance();
+  private PrecisionModel precisionModel;
+
+  /** Flag indicating that the old notation of coordinates in JTS is supported. */
+  private static final boolean ALLOW_OLD_JTS_COORDINATE_SYNTAX = true;
+
+  private boolean isAllowOldJtsCoordinateSyntax = ALLOW_OLD_JTS_COORDINATE_SYNTAX;
+
+  /** Flag indicating that the old notation of MultiPoint coordinates in JTS is supported. */
+  private static final boolean ALLOW_OLD_JTS_MULTIPOINT_SYNTAX = true;
+
+  private boolean isAllowOldJtsMultipointSyntax = ALLOW_OLD_JTS_MULTIPOINT_SYNTAX;
+
+  private boolean isFixStructure = false;
+
+  public WKTReader() {
+    this.geometryFactory = new GeometryFactory();
+    this.csFactory = geometryFactory.getCoordinateSequenceFactory();
+    this.precisionModel = geometryFactory.getPrecisionModel();
+  }
+
+  /**
+   * Sets a flag indicating, that coordinates may have 3 ordinate values even though no Z or M
+   * ordinate indicator is present. The default value is {@link #ALLOW_OLD_JTS_COORDINATE_SYNTAX}.
+   *
+   * @param value a boolean value
+   */
+  public void setIsOldJtsCoordinateSyntaxAllowed(boolean value) {
+    isAllowOldJtsCoordinateSyntax = value;
+  }
+
+  /**
+   * Sets a flag indicating, that point coordinates in a MultiPoint geometry must not be enclosed in
+   * paren. The default value is {@link #ALLOW_OLD_JTS_MULTIPOINT_SYNTAX}
+   *
+   * @param value a boolean value
+   */
+  public void setIsOldJtsMultiPointSyntaxAllowed(boolean value) {
+    isAllowOldJtsMultipointSyntax = value;
+  }
+
+  /**
+   * Sets a flag indicating that the structure of input geometry should be fixed so that the
+   * geometry can be constructed without error. This involves adding coordinates if the input
+   * coordinate sequence is shorter than required.
+   *
+   * @param isFixStructure true if the input structure should be fixed
+   * @see LinearRing#MINIMUM_VALID_SIZE
+   */
+  public void setFixStructure(boolean isFixStructure) {
+    this.isFixStructure = isFixStructure;
+  }
+
+  /**
+   * Reads a Well-Known Text representation of a {@link Geometry} from a {@link String}.
+   *
+   * @param wellKnownText one or more &lt;Geometry Tagged Text&gt; strings (see the OpenGIS Simple
+   *     Features Specification) separated by whitespace
+   * @return a <code>Geometry</code> specified by <code>wellKnownText</code>
+   * @throws ParseException if a parsing problem occurs
+   */
+  public S2Geography read(String wellKnownText) throws ParseException {
+    StringReader reader = new StringReader(wellKnownText);
+    try {
+      return read(reader);
+    } finally {
+      reader.close();
+    }
+  }
+
+  /**
+   * Reads a Well-Known Text representation of a {@link S2Geography} from a {@link Reader}.
+   *
+   * @param reader a Reader which will return a &lt;Geometry Tagged Text&gt; string (see the OpenGIS
+   *     Simple Features Specification)
+   * @return a <code>Geometry</code> read from <code>reader</code>
+   * @throws ParseException if a parsing problem occurs
+   */
+  public S2Geography read(Reader reader) throws ParseException {
+    StreamTokenizer tokenizer = createTokenizer(reader);
+    try {
+      return readGeometryTaggedText(tokenizer);
+    } catch (IOException e) {
+      throw new ParseException(e.toString());
+    }
+  }
+
+  /**
+   * Utility function to create the tokenizer
+   *
+   * @param reader a reader
+   * @return a WKT Tokenizer.
+   */
+  private static StreamTokenizer createTokenizer(Reader reader) {
+    StreamTokenizer tokenizer = new StreamTokenizer(reader);
+    // set tokenizer to NOT parse numbers
+    tokenizer.resetSyntax();
+    tokenizer.wordChars('a', 'z');
+    tokenizer.wordChars('A', 'Z');
+    tokenizer.wordChars(128 + 32, 255);
+    tokenizer.wordChars('0', '9');
+    tokenizer.wordChars('-', '-');
+    tokenizer.wordChars('+', '+');
+    tokenizer.wordChars('.', '.');
+    tokenizer.whitespaceChars(0, ' ');
+    tokenizer.commentChar('#');
+
+    return tokenizer;
+  }
+
+  /**
+   * Reads a <code>Coordinate</Code> from a stream using the given {@link StreamTokenizer}.
+   *
+   * <p>All ordinate values are read, but -depending on the {@link CoordinateSequenceFactory} of the
+   * underlying {@link GeometryFactory}- not necessarily all can be handled. Those are silently
+   * dropped.
+   *
+   * @param tokenizer the tokenizer to use
+   * @param ordinateFlags a bit-mask defining the ordinates to read.
+   * @param tryParen a value indicating if a starting {@link #L_PAREN} should be probed.
+   * @return a {@link Coordinate} of appropriate dimension containing the read ordinate values
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private Coordinate getCoordinate(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags, boolean tryParen)
+      throws IOException, ParseException {
+    boolean opened = false;
+    if (tryParen && isOpenerNext(tokenizer)) {
+      tokenizer.nextToken();
+      opened = true;
+    }
+
+    // create a sequence for one coordinate
+    int offsetM = ordinateFlags.contains(Ordinate.Z) ? 1 : 0;
+    Coordinate coord = createCoordinate(ordinateFlags);
+    coord.setOrdinate(CoordinateSequence.X, precisionModel.makePrecise(getNextNumber(tokenizer)));
+    coord.setOrdinate(CoordinateSequence.Y, precisionModel.makePrecise(getNextNumber(tokenizer)));
+
+    // additionally read other vertices
+    if (ordinateFlags.contains(Ordinate.Z))
+      coord.setOrdinate(CoordinateSequence.Z, getNextNumber(tokenizer));
+    if (ordinateFlags.contains(Ordinate.M))
+      coord.setOrdinate(CoordinateSequence.Z + offsetM, getNextNumber(tokenizer));
+
+    if (ordinateFlags.size() == 2
+        && this.isAllowOldJtsCoordinateSyntax
+        && isNumberNext(tokenizer)) {
+      coord.setOrdinate(CoordinateSequence.Z, getNextNumber(tokenizer));
+    }
+
+    // read close token if it was opened here
+    if (opened) {
+      getNextCloser(tokenizer);
+    }
+
+    return coord;
+  }
+
+  private Coordinate createCoordinate(EnumSet<Ordinate> ordinateFlags) {
+    boolean hasZ = ordinateFlags.contains(Ordinate.Z);
+    boolean hasM = ordinateFlags.contains(Ordinate.M);
+    if (hasZ && hasM) return new CoordinateXYZM();
+    if (hasM) return new CoordinateXYM();
+    if (hasZ || this.isAllowOldJtsCoordinateSyntax) return new Coordinate();
+    return new CoordinateXY();
+  }
+
+  /**
+   * Reads a <code>Coordinate</Code> from a stream using the given {@link StreamTokenizer}.
+   *
+   * <p>All ordinate values are read, but -depending on the {@link CoordinateSequenceFactory} of the
+   * underlying {@link GeometryFactory}- not necessarily all can be handled. Those are silently
+   * dropped.
+   *
+   * <p>
+   *
+   * @param tokenizer the tokenizer to use
+   * @param ordinateFlags a bit-mask defining the ordinates to read.
+   * @return a {@link CoordinateSequence} of length 1 containing the read ordinate values
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private CoordinateSequence getCoordinateSequence(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags, int minSize, boolean isRing)
+      throws IOException, ParseException {
+    if (getNextEmptyOrOpener(tokenizer).equals(WKTConstants.EMPTY))
+      return createCoordinateSequenceEmpty(ordinateFlags);
+
+    List<Coordinate> coordinates = new ArrayList<Coordinate>();
+    do {
+      coordinates.add(getCoordinate(tokenizer, ordinateFlags, false));
+    } while (getNextCloserOrComma(tokenizer).equals(COMMA));
+
+    if (isFixStructure) {
+      fixStructure(coordinates, minSize, isRing);
+    }
+    Coordinate[] coordArray = coordinates.toArray(new Coordinate[0]);
+    return csFactory.create(coordArray);
+  }
+
+  private static void fixStructure(List<Coordinate> coords, int minSize, boolean isRing) {
+    if (coords.size() == 0) return;
+    if (isRing && !isClosed(coords)) {
+      coords.add(coords.get(0).copy());
+    }
+    while (coords.size() < minSize) {
+      coords.add(coords.get(coords.size() - 1).copy());
+    }
+  }
+
+  private static boolean isClosed(List<Coordinate> coords) {
+    if (coords.size() == 0) return true;
+    if (coords.size() == 1 || !coords.get(0).equals2D(coords.get(coords.size() - 1))) {
+      return false;
+    }
+    return true;
+  }
+
+  private CoordinateSequence createCoordinateSequenceEmpty(EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    return csFactory.create(
+        0, toDimension(ordinateFlags), ordinateFlags.contains(Ordinate.M) ? 1 : 0);
+  }
+
+  /**
+   * Reads a <code>CoordinateSequence</Code> from a stream using the given {@link StreamTokenizer}
+   * for an old-style JTS MultiPoint (Point coordinates not enclosed in parentheses).
+   *
+   * <p>All ordinate values are read, but -depending on the {@link CoordinateSequenceFactory} of the
+   * underlying {@link GeometryFactory}- not necessarily all can be handled. Those are silently
+   * dropped.
+   *
+   * @param tokenizer the tokenizer to use
+   * @param ordinateFlags a bit-mask defining the ordinates to read.
+   * @return a {@link CoordinateSequence} of length 1 containing the read ordinate values
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered S
+   */
+  private CoordinateSequence getCoordinateSequenceOldMultiPoint(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+
+    List<Coordinate> coordinates = new ArrayList<Coordinate>();
+    do {
+      coordinates.add(getCoordinate(tokenizer, ordinateFlags, true));
+    } while (getNextCloserOrComma(tokenizer).equals(COMMA));
+
+    Coordinate[] coordArray = coordinates.toArray(new Coordinate[0]);
+    return csFactory.create(coordArray);
+  }
+
+  /**
+   * Computes the required dimension based on the given ordinate values. It is assumed that {@link
+   * Ordinate#X} and {@link Ordinate#Y} are included.
+   *
+   * @param ordinateFlags the ordinate bit-mask
+   * @return the number of dimensions required to store ordinates for the given bit-mask.
+   */
+  private int toDimension(EnumSet<Ordinate> ordinateFlags) {
+    int dimension = 2;
+    if (ordinateFlags.contains(Ordinate.Z)) dimension++;
+    if (ordinateFlags.contains(Ordinate.M)) dimension++;
+
+    if (dimension == 2 && this.isAllowOldJtsCoordinateSyntax) dimension++;
+
+    return dimension;
+  }
+
+  /**
+   * Tests if the next token in the stream is a number
+   *
+   * @param tokenizer the tokenizer
+   * @return {@code true} if the next token is a number, otherwise {@code false}
+   * @throws IOException if an I/O error occurs
+   */
+  private static boolean isNumberNext(StreamTokenizer tokenizer) throws IOException {
+    int type = tokenizer.nextToken();
+    tokenizer.pushBack();
+    return type == StreamTokenizer.TT_WORD;
+  }
+
+  /**
+   * Tests if the next token in the stream is a left opener ({@link #L_PAREN})
+   *
+   * @param tokenizer the tokenizer
+   * @return {@code true} if the next token is a {@link #L_PAREN}, otherwise {@code false}
+   * @throws IOException if an I/O error occurs
+   */
+  private static boolean isOpenerNext(StreamTokenizer tokenizer) throws IOException {
+    int type = tokenizer.nextToken();
+    tokenizer.pushBack();
+    return type == '(';
+  }
+
+  /**
+   * Parses the next number in the stream. Numbers with exponents are handled. <tt>NaN</tt> values
+   * are handled correctly, and the case of the "NaN" symbol is not significant.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   * @return the next number in the stream
+   * @throws ParseException if the next token is not a valid number
+   * @throws IOException if an I/O error occurs
+   */
+  private double getNextNumber(StreamTokenizer tokenizer) throws IOException, ParseException {
+    int type = tokenizer.nextToken();
+    switch (type) {
+      case StreamTokenizer.TT_WORD:
+        {
+          if (tokenizer.sval.equalsIgnoreCase(NAN_SYMBOL)) {
+            return Double.NaN;
+          } else {
+            try {
+              return Double.parseDouble(tokenizer.sval);
+            } catch (NumberFormatException ex) {
+              throw parseErrorWithLine(tokenizer, "Invalid number: " + tokenizer.sval);
+            }
+          }
+        }
+    }
+    throw parseErrorExpected(tokenizer, "number");
+  }
+
+  /**
+   * Returns the next EMPTY or L_PAREN in the stream as uppercase text.
+   *
+   * @return the next EMPTY or L_PAREN in the stream as uppercase text.
+   * @throws ParseException if the next token is not EMPTY or L_PAREN
+   * @throws IOException if an I/O error occurs
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   */
+  private static String getNextEmptyOrOpener(StreamTokenizer tokenizer)
+      throws IOException, ParseException {
+    String nextWord = getNextWord(tokenizer);
+    if (nextWord.equalsIgnoreCase(WKTConstants.Z)) {
+      // z = true;
+      nextWord = getNextWord(tokenizer);
+    } else if (nextWord.equalsIgnoreCase(WKTConstants.M)) {
+      // m = true;
+      nextWord = getNextWord(tokenizer);
+    } else if (nextWord.equalsIgnoreCase(WKTConstants.ZM)) {
+      // z = true;
+      // m = true;
+      nextWord = getNextWord(tokenizer);
+    }
+    if (nextWord.equals(WKTConstants.EMPTY) || nextWord.equals(L_PAREN)) {
+      return nextWord;
+    }
+    throw parseErrorExpected(tokenizer, WKTConstants.EMPTY + " or " + L_PAREN);
+  }
+
+  /**
+   * Returns the next ordinate flag information in the stream as uppercase text. This can be Z, M or
+   * ZM.
+   *
+   * @return the next EMPTY or L_PAREN in the stream as uppercase text.
+   * @throws ParseException if the next token is not EMPTY or L_PAREN
+   * @throws IOException if an I/O error occurs
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   */
+  private static EnumSet<Ordinate> getNextOrdinateFlags(StreamTokenizer tokenizer)
+      throws IOException, ParseException {
+
+    EnumSet<Ordinate> result = EnumSet.of(Ordinate.X, Ordinate.Y);
+
+    String nextWord = lookAheadWord(tokenizer).toUpperCase(Locale.ROOT);
+    if (nextWord.equalsIgnoreCase(WKTConstants.Z)) {
+      tokenizer.nextToken();
+      result.add(Ordinate.Z);
+    } else if (nextWord.equalsIgnoreCase(WKTConstants.M)) {
+      tokenizer.nextToken();
+      result.add(Ordinate.M);
+    } else if (nextWord.equalsIgnoreCase(WKTConstants.ZM)) {
+      tokenizer.nextToken();
+      result.add(Ordinate.Z);
+      result.add(Ordinate.M);
+    }
+    return result;
+  }
+
+  /**
+   * Returns the next word in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next token must
+   *     be a word.
+   * @return the next word in the stream as uppercase text
+   * @throws ParseException if the next token is not a word
+   * @throws IOException if an I/O error occurs
+   */
+  private static String lookAheadWord(StreamTokenizer tokenizer)
+      throws IOException, ParseException {
+    String nextWord = getNextWord(tokenizer);
+    tokenizer.pushBack();
+    return nextWord;
+  }
+
+  /**
+   * Returns the next {@link #R_PAREN} or {@link #COMMA} in the stream.
+   *
+   * @return the next R_PAREN or COMMA in the stream
+   * @throws ParseException if the next token is not R_PAREN or COMMA
+   * @throws IOException if an I/O error occurs
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   */
+  private static String getNextCloserOrComma(StreamTokenizer tokenizer)
+      throws IOException, ParseException {
+    String nextWord = getNextWord(tokenizer);
+    if (nextWord.equals(COMMA) || nextWord.equals(R_PAREN)) {
+      return nextWord;
+    }
+    throw parseErrorExpected(tokenizer, COMMA + " or " + R_PAREN);
+  }
+
+  /**
+   * Returns the next {@link #R_PAREN} in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next token must
+   *     be R_PAREN.
+   * @return the next R_PAREN in the stream
+   * @throws ParseException if the next token is not R_PAREN
+   * @throws IOException if an I/O error occurs
+   */
+  private String getNextCloser(StreamTokenizer tokenizer) throws IOException, ParseException {
+    String nextWord = getNextWord(tokenizer);
+    if (nextWord.equals(R_PAREN)) {
+      return nextWord;
+    }
+    throw parseErrorExpected(tokenizer, R_PAREN);
+  }
+
+  /**
+   * Returns the next word in the stream.
+   *
+   * @return the next word in the stream as uppercase text
+   * @throws ParseException if the next token is not a word
+   * @throws IOException if an I/O error occurs
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   */
+  private static String getNextWord(StreamTokenizer tokenizer) throws IOException, ParseException {
+    int type = tokenizer.nextToken();
+    switch (type) {
+      case StreamTokenizer.TT_WORD:
+        String word = tokenizer.sval;
+        if (word.equalsIgnoreCase(WKTConstants.EMPTY)) return WKTConstants.EMPTY;
+        return word;
+
+      case '(':
+        return L_PAREN;
+      case ')':
+        return R_PAREN;
+      case ',':
+        return COMMA;
+    }
+    throw parseErrorExpected(tokenizer, "word");
+  }
+
+  /**
+   * Creates a formatted ParseException reporting that the current token was unexpected.
+   *
+   * @param expected a description of what was expected
+   */
+  private static ParseException parseErrorExpected(StreamTokenizer tokenizer, String expected) {
+    // throws Asserts for tokens that should never be seen
+    if (tokenizer.ttype == StreamTokenizer.TT_NUMBER)
+      Assert.shouldNeverReachHere("Unexpected NUMBER token");
+    if (tokenizer.ttype == StreamTokenizer.TT_EOL)
+      Assert.shouldNeverReachHere("Unexpected EOL token");
+
+    String tokenStr = tokenString(tokenizer);
+    return parseErrorWithLine(tokenizer, "Expected " + expected + " but found " + tokenStr);
+  }
+
+  /**
+   * Creates a formatted ParseException reporting that the current token was unexpected.
+   *
+   * @param msg a description of what was expected
+   */
+  private static ParseException parseErrorWithLine(StreamTokenizer tokenizer, String msg) {
+    return new ParseException(msg + " (line " + tokenizer.lineno() + ")");
+  }
+
+  /**
+   * Gets a description of the current token type
+   *
+   * @param tokenizer the tokenizer
+   * @return a description of the current token
+   */
+  private static String tokenString(StreamTokenizer tokenizer) {
+    switch (tokenizer.ttype) {
+      case StreamTokenizer.TT_NUMBER:
+        return "<NUMBER>";
+      case StreamTokenizer.TT_EOL:
+        return "End-of-Line";
+      case StreamTokenizer.TT_EOF:
+        return "End-of-Stream";
+      case StreamTokenizer.TT_WORD:
+        return "'" + tokenizer.sval + "'";
+    }
+    return "'" + (char) tokenizer.ttype + "'";
+  }
+
+  /**
+   * Creates a <code>Geometry</code> using the next token in the stream.
+   *
+   * @return a <code>Geometry</code> specified by the next token in the stream
+   * @throws ParseException if the coordinates used to create a <code>Polygon</code> shell and holes
+   *     do not form closed linestrings, or if an unexpected token was encountered
+   * @throws IOException if an I/O error occurs
+   * @param tokenizer tokenizer over a stream of text in Well-known Text
+   */
+  private S2Geography readGeometryTaggedText(StreamTokenizer tokenizer)
+      throws IOException, ParseException {
+    String type;
+
+    EnumSet<Ordinate> ordinateFlags = EnumSet.of(Ordinate.X, Ordinate.Y);
+    type = getNextWord(tokenizer).toUpperCase(Locale.ROOT);
+    if (type.endsWith(WKTConstants.ZM)) {
+      ordinateFlags.add(Ordinate.Z);
+      ordinateFlags.add(Ordinate.M);
+    } else if (type.endsWith(WKTConstants.Z)) {
+      ordinateFlags.add(Ordinate.Z);
+    } else if (type.endsWith(WKTConstants.M)) {
+      ordinateFlags.add(Ordinate.M);
+    }
+    return readGeometryTaggedText(tokenizer, type, ordinateFlags);
+  }
+
+  private S2Geography readGeometryTaggedText(
+      StreamTokenizer tokenizer, String type, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+
+    if (ordinateFlags.size() == 2) {
+      ordinateFlags = getNextOrdinateFlags(tokenizer);
+    }
+
+    // if we can create a sequence with the required dimension everything is ok, otherwise
+    // we need to take a different coordinate sequence factory.
+    // It would be good to not have to try/catch this but if the CoordinateSequenceFactory
+    // exposed a value indicating which min/max dimension it can handle or even an
+    // ordinate bit-flag.
+    try {
+      csFactory.create(0, toDimension(ordinateFlags), ordinateFlags.contains(Ordinate.M) ? 1 : 0);
+    } catch (Exception e) {
+      geometryFactory =
+          new GeometryFactory(
+              geometryFactory.getPrecisionModel(), geometryFactory.getSRID(), csFactoryXYZM);
+    }
+
+    if (isTypeName(tokenizer, type, WKTConstants.POINT)) {
+      return readPointText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.LINESTRING)) {
+      return readPolylineText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.LINEARRING)) {
+      return readPolygonText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.POLYGON)) {
+      return readPolygonText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.MULTIPOINT)) {
+      return readMultiPointText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.MULTILINESTRING)) {
+      return readMultiPolylineText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.MULTIPOLYGON)) {
+      return readMultiPolygonText(tokenizer, ordinateFlags);
+    } else if (isTypeName(tokenizer, type, WKTConstants.GEOMETRYCOLLECTION)) {
+      return readGeographyCollectionText(tokenizer, ordinateFlags);
+    }
+    throw parseErrorWithLine(tokenizer, "Unknown geometry type: " + type);
+  }
+
+  private boolean isTypeName(StreamTokenizer tokenizer, String type, String typeName)
+      throws ParseException {
+    if (!type.startsWith(typeName)) return false;
+
+    String modifiers = type.substring(typeName.length());
+    boolean isValidMod =
+        modifiers.length() <= 2
+            && (modifiers.length() == 0
+                || modifiers.equals(WKTConstants.Z)
+                || modifiers.equals(WKTConstants.M)
+                || modifiers.equals(WKTConstants.ZM));
+    if (!isValidMod) {
+      throw parseErrorWithLine(tokenizer, "Invalid dimension modifiers: " + type);
+    }
+
+    return true;
+  }
+
+  /**
+   * Creates a <code>Point</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;Point Text&gt;.
+   * @return a <code>Point</code> specified by the next token in the stream
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private SinglePointGeography readPointText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence pts = getCoordinateSequence(tokenizer, ordinateFlags, 1, false);
+    // If X and Y are NaN create a empty point
+    if (pts.size() <= 0 || Double.isNaN(pts.getX(0)) || Double.isNaN(pts.getY(0))) {
+      return new SinglePointGeography();
+    }
+    double lon = pts.getX(0);
+    double lat = pts.getY(0);
+    S2Point s2Point = S2LatLng.fromDegrees(lat, lon).toPoint();
+
+    // Build via S2Builder + S2PointVectorLayer
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PointVectorLayer layer = new S2PointVectorLayer();
+    builder.startLayer(layer);
+    builder.addPoint(s2Point);
+
+    // must call build() before reading out the points
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("Failed to build S2 point layer: " + error.text());
+    }
+    // Extract the resulting points
+    List<S2Point> points = layer.getPointVector();
+    if (points.isEmpty()) {
+      return new SinglePointGeography();
+    }
+    return new SinglePointGeography(points.get(0));
+  }
+
+  /**
+   * Creates a <code>LineString</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;LineString Text&gt;.
+   * @return a <code>LineString</code> specified by the next token in the stream
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private SinglePolylineGeography readPolylineText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence seq =
+        getCoordinateSequence(tokenizer, ordinateFlags, LineString.MINIMUM_VALID_SIZE, false);
+    if (seq.size() < 2) {
+      // empty or extended-but-all-NaN → empty geography
+      return new SinglePolylineGeography();
+    }
+
+    List<S2Point> pts = new ArrayList<>(seq.size());
+    for (int i = 0; i < seq.size(); i++) {
+      double lon = seq.getX(i);
+      double lat = seq.getY(i);
+      pts.add(S2LatLng.fromDegrees(lat, lon).toPoint());
+    }
+
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PolylineLayer layer = new S2PolylineLayer();
+    builder.startLayer(layer);
+
+    builder.addPolyline(new S2Polyline(pts));
+
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("Failed to build S2 polyline: " + error.text());
+    }
+    S2Polyline s2poly = layer.getPolyline();
+    return new SinglePolylineGeography(s2poly);
+  }
+
+  /**
+   * Creates a <code>LinearRing</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;LineString Text&gt;.
+   * @return a <code>LinearRing</code> specified by the next token in the stream
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if the coordinates used to create the <code>LinearRing</code> do not
+   *     form a closed linestring, or if an unexpected token was encountered
+   */
+  private S2Loop readLoopText(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    CoordinateSequence seq =
+        getCoordinateSequence(tokenizer, ordinateFlags, LinearRing.MINIMUM_VALID_SIZE, true);
+    // build the loop
+    List<S2Point> pts = new ArrayList<>(seq.size());
+    for (int i = 0; i < seq.size(); i++) {
+      pts.add(S2LatLng.fromDegrees(seq.getY(i), seq.getX(i)).toPoint());
+    }
+    return new S2Loop(pts);
+  }
+
+  /**
+   * Creates a <code>MultiPoint</code> using the next tokens in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;MultiPoint Text&gt;.
+   * @return a <code>MultiPoint</code> specified by the next token in the stream
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private PointGeography readMultiPointText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    String nextToken = getNextEmptyOrOpener(tokenizer);
+    if (nextToken.equals(WKTConstants.EMPTY)) {
+      return new PointGeography();
+    }
+
+    // check for old-style JTS syntax (no parentheses surrounding Point coordinates) and parse it if
+    // present
+    // MD 2009-02-21 - this is only provided for backwards compatibility for a few versions
+    if (isAllowOldJtsMultipointSyntax) {
+      String nextWord = lookAheadWord(tokenizer);
+      if (nextWord != L_PAREN && nextWord != WKTConstants.EMPTY) {
+        CoordinateSequence pts = getCoordinateSequenceOldMultiPoint(tokenizer, ordinateFlags);
+        if (Double.isNaN(pts.getX(0)) || Double.isNaN(pts.getY(0))) {
+          return new PointGeography();
+        }
+        List<S2Point> points = new ArrayList<>(pts.size());
+        // Build via S2Builder + S2PointVectorLayer
+        S2Builder builder = new S2Builder.Builder().build();
+        S2PointVectorLayer layer = new S2PointVectorLayer();
+        // must call build() before reading out the points
+        S2Error error = new S2Error();
+        for (int i = 0; i < pts.size(); i++) {
+          double lon = pts.getX(i);
+          double lat = pts.getY(i);
+          S2Point s2Point = S2LatLng.fromDegrees(lat, lon).toPoint();
+
+          builder.startLayer(layer);
+          builder.addPoint(s2Point);
+
+          if (!builder.build(error)) {
+            throw new IOException("Failed to build S2 point layer: " + error.text());
+          }
+        }
+        for (int i = 0; i < layer.getPointVector().size(); i++) {
+          // Extract the resulting points
+          points.add(layer.getPointVector().get(i));
+        }
+        return new PointGeography(points);
+      }
+    }
+
+    List<S2Point> points = new ArrayList<S2Point>();
+    PointGeography point = readPointText(tokenizer, ordinateFlags);
+    points.addAll(point.getPoints());
+    nextToken = getNextCloserOrComma(tokenizer);
+    while (nextToken.equals(COMMA)) {
+      point = readPointText(tokenizer, ordinateFlags);
+      points.addAll(point.getPoints());
+      nextToken = getNextCloserOrComma(tokenizer);
+    }
+    return new PointGeography(points);
+  }
+
+  /**
+   * Creates a <code>Polygon</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;Polygon Text&gt;.
+   * @return a <code>Polygon</code> specified by the next token in the stream
+   * @throws ParseException if the coordinates used to create the <code>Polygon</code> shell and
+   *     holes do not form closed linestrings, or if an unexpected token was encountered.
+   * @throws IOException if an I/O error occurs
+   */
+  private PolygonGeography readPolygonText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    String nextToken = getNextEmptyOrOpener(tokenizer);
+    if (nextToken.equals(WKTConstants.EMPTY)) {
+      return new PolygonGeography();
+    }
+
+    List<S2Loop> holes = new ArrayList<S2Loop>();
+
+    S2Loop shell = readLoopText(tokenizer, ordinateFlags);
+    holes.add(shell);
+    nextToken = getNextCloserOrComma(tokenizer);
+    while (nextToken.equals(COMMA)) {
+      S2Loop hole = readLoopText(tokenizer, ordinateFlags);
+      holes.add(hole);
+      nextToken = getNextCloserOrComma(tokenizer);
+    }
+
+    // Now feed those loops into S2Builder + S2PolygonLayer:
+    S2Builder builder = new S2Builder.Builder().build();
+    S2PolygonLayer polyLayer = new S2PolygonLayer();
+    builder.startLayer(polyLayer);
+
+    // add shell + holes
+    for (S2Loop loop : holes) {
+      builder.addLoop(loop);
+    }
+
+    // build
+    S2Error error = new S2Error();
+    if (!builder.build(error)) {
+      throw new IOException("S2Builder failed: " + error.text());
+    }
+
+    // extract the stitched polygon
+    S2Polygon s2poly = polyLayer.getPolygon();
+
+    // wrap in your PolygonGeography
+    return new PolygonGeography(s2poly);
+  }
+
+  /**
+   * Creates a <code>MultiLineString</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;MultiLineString Text&gt;.
+   * @return a <code>MultiLineString</code> specified by the next token in the stream
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private PolylineGeography readMultiPolylineText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    String nextToken = getNextEmptyOrOpener(tokenizer);
+    if (nextToken.equals(WKTConstants.EMPTY)) {
+      return new PolylineGeography();
+    }
+
+    List<S2Polyline> lineStrings = new ArrayList<S2Polyline>();
+    do {
+      PolylineGeography lineString = readPolylineText(tokenizer, ordinateFlags);
+      lineStrings.addAll(lineString.getPolylines());
+      nextToken = getNextCloserOrComma(tokenizer);
+    } while (nextToken.equals(COMMA));
+    return new PolylineGeography(lineStrings);
+  }
+
+  /**
+   * Creates a <code>MultiPolygon</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;MultiPolygon Text&gt;.
+   * @return a <code>MultiPolygon</code> specified by the next token in the stream, or if if the
+   *     coordinates used to create the <code>Polygon</code> shells and holes do not form closed
+   *     linestrings.
+   * @throws IOException if an I/O error occurs
+   * @throws ParseException if an unexpected token was encountered
+   */
+  private MultiPolygonGeography readMultiPolygonText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    String nextToken = getNextEmptyOrOpener(tokenizer);
+    if (nextToken.equals(WKTConstants.EMPTY)) {
+      return new MultiPolygonGeography(new ArrayList<>());
+    }
+    List<S2Polygon> polygons = new ArrayList<S2Polygon>();
+    do {
+      PolygonGeography polygon = readPolygonText(tokenizer, ordinateFlags);
+      polygons.add(polygon.polygon);
+      nextToken = getNextCloserOrComma(tokenizer);
+    } while (nextToken.equals(COMMA));
+    return new MultiPolygonGeography(polygons);
+  }
+
+  /**
+   * Creates a <code>GeometryCollection</code> using the next token in the stream.
+   *
+   * @param tokenizer tokenizer over a stream of text in Well-known Text format. The next tokens
+   *     must form a &lt;GeometryCollection Text&gt;.
+   * @return a <code>GeometryCollection</code> specified by the next token in the stream
+   * @throws ParseException if the coordinates used to create a <code>Polygon</code> shell and holes
+   *     do not form closed linestrings, or if an unexpected token was encountered
+   * @throws IOException if an I/O error occurs
+   */
+  private GeographyCollection readGeographyCollectionText(
+      StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+      throws IOException, ParseException {
+    String nextToken = getNextEmptyOrOpener(tokenizer);
+    if (nextToken.equals(WKTConstants.EMPTY)) {
+      return new GeographyCollection();
+    }
+    List<S2Geography> geometries = new ArrayList<S2Geography>();
+    do {
+      S2Geography geometry = readGeometryTaggedText(tokenizer);
+      geometries.add(geometry);
+      nextToken = getNextCloserOrComma(tokenizer);
+    } while (nextToken.equals(COMMA));
+    return new GeographyCollection(geometries);
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/S2Geography/WKTWriter.java
+++ b/common/src/main/java/org/apache/sedona/common/S2Geography/WKTWriter.java
@@ -1,0 +1,887 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.EnumSet;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.Ordinate;
+import org.locationtech.jts.io.OrdinateFormat;
+import org.locationtech.jts.io.WKTConstants;
+import org.locationtech.jts.util.Assert;
+
+public class WKTWriter {
+  /**
+   * Generates the WKT for a <tt>POINT</tt> specified by a {@link Coordinate}.
+   *
+   * @param p0 the point coordinate
+   * @return the WKT
+   */
+  public static String toPoint(Coordinate p0) {
+    return WKTConstants.POINT + " ( " + format(p0) + " )";
+  }
+
+  public static String format(Coordinate p) {
+    return format(p.x, p.y);
+  }
+
+  private static String format(double x, double y) {
+    return OrdinateFormat.DEFAULT.format(x) + " " + OrdinateFormat.DEFAULT.format(y);
+  }
+
+  private static final int INDENT = 2;
+  private static final int OUTPUT_DIMENSION = 2;
+
+  /**
+   * Creates the <code>DecimalFormat</code> used to write <code>double</code>s with a sufficient
+   * number of decimal places.
+   *
+   * @param precisionModel the <code>PrecisionModel</code> used to determine the number of decimal
+   *     places to write.
+   * @return a <code>DecimalFormat</code> that write <code>double</code> s without scientific
+   *     notation.
+   */
+  private static OrdinateFormat createFormatter(PrecisionModel precisionModel) {
+    return OrdinateFormat.create(precisionModel.getMaximumSignificantDigits());
+  }
+
+  /**
+   * Returns a <code>String</code> of repeated characters.
+   *
+   * @param ch the character to repeat
+   * @param count the number of times to repeat the character
+   * @return a <code>String</code> of characters
+   */
+  private static String stringOfChar(char ch, int count) {
+    StringBuilder buf = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      buf.append(ch);
+    }
+    return buf.toString();
+  }
+
+  private EnumSet<Ordinate> outputOrdinates;
+  private final int outputDimension;
+  private PrecisionModel precisionModel = null;
+  private OrdinateFormat ordinateFormat = null;
+  private boolean isFormatted = false;
+  private int coordsPerLine = -1;
+  private String indentTabStr;
+
+  /** Creates a new WKTWriter with default settings */
+  public WKTWriter() {
+    this(OUTPUT_DIMENSION);
+  }
+
+  /**
+   * Creates a writer that writes {@link Geometry}s with the given output dimension (2 to 4). The
+   * output follows the following rules:
+   *
+   * <ul>
+   *   <li>If the specified <b>output dimension is 3</b> and the <b>z is measure flag is set to
+   *       true</b>, the Z value of coordinates will be written if it is present (i.e. if it is not
+   *       <code>Double.NaN</code>)
+   *   <li>If the specified <b>output dimension is 3</b> and the <b>z is measure flag is set to
+   *       false</b>, the Measure value of coordinates will be written if it is present (i.e. if it
+   *       is not <code>Double.NaN</code>)
+   *   <li>If the specified <b>output dimension is 4</b>, the Z value of coordinates will be written
+   *       even if it is not present when the Measure value is present. The Measure value of
+   *       coordinates will be written if it is present (i.e. if it is not <code>Double.NaN</code>)
+   * </ul>
+   *
+   * See also {@link #setOutputOrdinates(EnumSet)}
+   *
+   * @param outputDimension the coordinate dimension to output (2 to 4)
+   */
+  public WKTWriter(int outputDimension) {
+
+    setTab(INDENT);
+    this.outputDimension = outputDimension;
+    setPrecisionModel(new PrecisionModel());
+
+    if (outputDimension < 2 || outputDimension > 4)
+      throw new IllegalArgumentException("Invalid output dimension (must be 2 to 4)");
+
+    this.outputOrdinates = EnumSet.of(Ordinate.X, Ordinate.Y);
+    if (outputDimension > 2) outputOrdinates.add(Ordinate.Z);
+    if (outputDimension > 3) outputOrdinates.add(Ordinate.M);
+  }
+
+  /**
+   * Sets whether the output will be formatted.
+   *
+   * @param isFormatted true if the output is to be formatted
+   */
+  public void setFormatted(boolean isFormatted) {
+    this.isFormatted = isFormatted;
+  }
+
+  /**
+   * Sets the maximum number of coordinates per line written in formatted output. If the provided
+   * coordinate number is &lt;= 0, coordinates will be written all on one line.
+   *
+   * @param coordsPerLine the number of coordinates per line to output.
+   */
+  public void setMaxCoordinatesPerLine(int coordsPerLine) {
+    this.coordsPerLine = coordsPerLine;
+  }
+
+  /**
+   * Sets the tab size to use for indenting.
+   *
+   * @param size the number of spaces to use as the tab string
+   * @throws IllegalArgumentException if the size is non-positive
+   */
+  public void setTab(int size) {
+    if (size <= 0) throw new IllegalArgumentException("Tab count must be positive");
+    this.indentTabStr = stringOfChar(' ', size);
+  }
+
+  /**
+   * Sets the {@link Ordinate} that are to be written. Possible members are:
+   *
+   * <ul>
+   *   <li>{@link Ordinate#X}
+   *   <li>{@link Ordinate#Y}
+   *   <li>{@link Ordinate#Z}
+   *   <li>{@link Ordinate#M}
+   * </ul>
+   *
+   * Values of {@link Ordinate#X} and {@link Ordinate#Y} are always assumed and not particularly
+   * checked for.
+   *
+   * @param outputOrdinates A set of {@link Ordinate} values
+   */
+  public void setOutputOrdinates(EnumSet<Ordinate> outputOrdinates) {
+
+    this.outputOrdinates.remove(Ordinate.Z);
+    this.outputOrdinates.remove(Ordinate.M);
+
+    if (this.outputDimension == 3) {
+      if (outputOrdinates.contains(Ordinate.Z)) this.outputOrdinates.add(Ordinate.Z);
+      else if (outputOrdinates.contains(Ordinate.M)) this.outputOrdinates.add(Ordinate.M);
+    }
+    if (this.outputDimension == 4) {
+      if (outputOrdinates.contains(Ordinate.Z)) this.outputOrdinates.add(Ordinate.Z);
+      if (outputOrdinates.contains(Ordinate.M)) this.outputOrdinates.add(Ordinate.M);
+    }
+  }
+
+  /**
+   * Gets a bit-pattern defining which ordinates should be
+   *
+   * @return an ordinate bit-pattern
+   * @see #setOutputOrdinates(EnumSet)
+   */
+  public EnumSet<Ordinate> getOutputOrdinates() {
+    return this.outputOrdinates;
+  }
+
+  /**
+   * Sets a {@link PrecisionModel} that should be used on the ordinates written.
+   *
+   * <p>If none/{@code null} is assigned, the precision model of the {@link Geometry#getFactory()}
+   * is used.
+   *
+   * <p>Note: The precision model is applied to all ordinate values, not just x and y.
+   *
+   * @param precisionModel the flag indicating if {@link Coordinate#z}/{} is actually a measure
+   *     value.
+   */
+  public void setPrecisionModel(PrecisionModel precisionModel) {
+    this.precisionModel = precisionModel;
+    this.ordinateFormat = OrdinateFormat.create(precisionModel.getMaximumSignificantDigits());
+  }
+
+  /**
+   * Converts a <code>Geometry</code> to its Well-known Text representation.
+   *
+   * @param geometry a <code>Geometry</code> to process
+   * @return a &lt;Geometry Tagged Text&gt; string (see the OpenGIS Simple Features Specification)
+   */
+  public String write(S2Geography geometry) {
+    Writer sw = new StringWriter();
+
+    try {
+      writeFormatted(geometry, false, sw);
+    } catch (IOException ex) {
+      Assert.shouldNeverReachHere();
+    }
+    return sw.toString();
+  }
+
+  /**
+   * Converts a <code>Geometry</code> to its Well-known Text representation.
+   *
+   * @param geometry a <code>Geometry</code> to process
+   */
+  public void write(S2Geography geometry, Writer writer) throws IOException {
+    // write the geometry
+    writeFormatted(geometry, isFormatted, writer);
+  }
+
+  /**
+   * Converts a <code>Geometry</code> to its Well-known Text representation.
+   *
+   * @param geometry a <code>Geometry</code> to process
+   */
+  private void writeFormatted(S2Geography geometry, boolean useFormatting, Writer writer)
+      throws IOException {
+    OrdinateFormat formatter = getFormatter(geometry);
+    // append the WKT
+    appendGeometryTaggedText(geometry, useFormatting, writer, formatter);
+  }
+
+  private OrdinateFormat getFormatter(S2Geography geometry) {
+    // if present use the cached formatter
+    if (ordinateFormat != null) return ordinateFormat;
+
+    // no precision model was specified, so use the geometry's
+    PrecisionModel pm = new PrecisionModel(); // geometry.getPrecisionModel();
+    OrdinateFormat formatter = createFormatter(pm);
+    return formatter;
+  }
+
+  /**
+   * Converts a <code>Geometry</code> to &lt;Geometry Tagged Text&gt; format, then appends it to the
+   * writer.
+   *
+   * @param geometry the <code>Geometry</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendGeometryTaggedText(
+      S2Geography geometry, boolean useFormatting, Writer writer, OrdinateFormat formatter)
+      throws IOException {
+    EnumSet<Ordinate> seq = getOutputOrdinates();
+    // Append the WKT
+    appendGeometryTaggedText(geometry, seq, useFormatting, 0, writer, formatter);
+  }
+  /**
+   * Converts a <code>Geometry</code> to &lt;Geometry Tagged Text&gt; format, then appends it to the
+   * writer.
+   *
+   * @param geometry the <code>Geometry</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendGeometryTaggedText(
+      S2Geography geometry,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    // indent before writing
+    indent(useFormatting, level, writer);
+
+    // ——— Handle Points ———
+    if (geometry instanceof SinglePointGeography) {
+      appendPointTaggedText(
+          (SinglePointGeography) geometry,
+          outputOrdinates,
+          useFormatting,
+          level,
+          writer,
+          formatter);
+      return;
+    }
+
+    if (geometry instanceof PointGeography) {
+      appendMultiPointTaggedText(
+          (PointGeography) geometry, outputOrdinates, useFormatting, level, writer, formatter);
+      return;
+    }
+
+    // ——— Handle LineStrings ———
+    if (geometry instanceof SinglePolylineGeography) {
+      appendPolylineTaggedText(
+          (SinglePolylineGeography) geometry,
+          outputOrdinates,
+          useFormatting,
+          level,
+          writer,
+          formatter);
+      return;
+    }
+
+    if (geometry instanceof PolylineGeography) {
+      appendMultiLineStringTaggedText(
+          (PolylineGeography) geometry, outputOrdinates, useFormatting, level, writer, formatter);
+      return;
+    }
+
+    // ——— Handle Polygons ———
+    if (geometry instanceof PolygonGeography) {
+      appendPolygonTaggedText(
+          (PolygonGeography) geometry, outputOrdinates, useFormatting, level, writer, formatter);
+      return;
+    }
+
+    if (geometry instanceof MultiPolygonGeography) {
+      appendMultiPolygonTaggedText(
+          (MultiPolygonGeography) geometry,
+          outputOrdinates,
+          useFormatting,
+          level,
+          writer,
+          formatter);
+      return;
+    }
+
+    // ——— Handle Collections ———
+    if (geometry instanceof GeographyCollection) {
+      appendGeometryCollectionTaggedText(
+          (GeographyCollection) geometry, outputOrdinates, useFormatting, level, writer, formatter);
+      return;
+    }
+
+    Assert.shouldNeverReachHere("Unsupported Geometry implementation: " + geometry.getClass());
+  }
+
+  /**
+   * Converts a <code>Coordinate</code> to &lt;Point Tagged Text&gt; format, then appends it to the
+   * writer.
+   *
+   * @param point the <code>Point</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use when writing numbers
+   */
+  private void appendPointTaggedText(
+      PointGeography point,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.POINT);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendSequenceText(
+        point.getCoordinateSequence(),
+        outputOrdinates,
+        useFormatting,
+        level,
+        false,
+        writer,
+        formatter);
+  }
+
+  /**
+   * Converts a <code>LineString</code> to &lt;LineString Tagged Text&gt; format, then appends it to
+   * the writer.
+   *
+   * @param lineString the <code>LineString</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendPolylineTaggedText(
+      PolylineGeography lineString,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.LINESTRING);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendSequenceText(
+        lineString.getCoordinateSequence(),
+        outputOrdinates,
+        useFormatting,
+        level,
+        false,
+        writer,
+        formatter);
+  }
+  /**
+   * Converts a <code>Polygon</code> to &lt;Polygon Tagged Text&gt; format, then appends it to the
+   * writer.
+   *
+   * @param polygon the <code>Polygon</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendPolygonTaggedText(
+      PolygonGeography polygon,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.POLYGON);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendPolygonText(polygon, outputOrdinates, useFormatting, level, false, writer, formatter);
+  }
+
+  /**
+   * Converts a <code>MultiPoint</code> to &lt;MultiPoint Tagged Text&gt; format, then appends it to
+   * the writer.
+   *
+   * @param multipoint the <code>MultiPoint</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendMultiPointTaggedText(
+      PointGeography multipoint,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.MULTIPOINT);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendMultiPointText(multipoint, outputOrdinates, useFormatting, level, writer, formatter);
+  }
+
+  /**
+   * Converts a <code>MultiLineString</code> to &lt;MultiLineString Tagged Text&gt; format, then
+   * appends it to the writer.
+   *
+   * @param multiLineString the <code>MultiLineString</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendMultiLineStringTaggedText(
+      PolylineGeography multiLineString,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.MULTILINESTRING);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendMultiLineStringText(
+        multiLineString, outputOrdinates, useFormatting, level, /*false, */ writer, formatter);
+  }
+
+  /**
+   * Converts a <code>MultiPolygon</code> to &lt;MultiPolygon Tagged Text&gt; format, then appends
+   * it to the writer.
+   *
+   * @param multiPolygon the <code>MultiPolygon</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendMultiPolygonTaggedText(
+      MultiPolygonGeography multiPolygon,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.MULTIPOLYGON);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendMultiPolygonText(multiPolygon, outputOrdinates, useFormatting, level, writer, formatter);
+  }
+
+  /**
+   * Converts a <code>GeometryCollection</code> to &lt;GeometryCollection Tagged Text&gt; format,
+   * then appends it to the writer.
+   *
+   * @param geometryCollection the <code>GeometryCollection</code> to process
+   * @param useFormatting flag indicating that the output should be formatted
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the <code>DecimalFormatter</code> to use to convert from a precise coordinate
+   *     to an external coordinate
+   */
+  private void appendGeometryCollectionTaggedText(
+      GeographyCollection geometryCollection,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(WKTConstants.GEOMETRYCOLLECTION);
+    writer.write(" ");
+    appendOrdinateText(outputOrdinates, writer);
+    appendGeometryCollectionText(
+        geometryCollection, outputOrdinates, useFormatting, level, writer, formatter);
+  }
+
+  /**
+   * Appends the i'th coordinate from the sequence to the writer
+   *
+   * <p>If the {@code seq} has coordinates that are {@link double.NAN}, these are not written, even
+   * though {@link #outputDimension} suggests this.
+   *
+   * @param seq the <code>CoordinateSequence</code> to process
+   * @param i the index of the coordinate to write
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values
+   */
+  private void appendCoordinate(
+      CoordinateSequence seq,
+      EnumSet<Ordinate> outputOrdinates,
+      int i,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    writer.write(writeNumber(seq.getX(i), formatter) + " " + writeNumber(seq.getY(i), formatter));
+
+    if (outputOrdinates.contains(Ordinate.Z)) {
+      writer.write(" ");
+      writer.write(writeNumber(seq.getZ(i), formatter));
+    }
+
+    if (outputOrdinates.contains(Ordinate.M)) {
+      writer.write(" ");
+      writer.write(writeNumber(seq.getM(i), formatter));
+    }
+  }
+
+  /**
+   * Converts a <code>double</code> to a <code>String</code>, not in scientific notation.
+   *
+   * @param d the <code>double</code> to convert
+   * @return the <code>double</code> as a <code>String</code>, not in scientific notation
+   */
+  private static String writeNumber(double d, OrdinateFormat formatter) {
+    return formatter.format(d);
+  }
+
+  /**
+   * Appends additional ordinate information. This function may
+   *
+   * <ul>
+   *   <li>append 'Z' if in {@code outputOrdinates} the {@link Ordinate#Z} value is included
+   *   <li>append 'M' if in {@code outputOrdinates} the {@link Ordinate#M} value is included
+   *   <li>append 'ZM' if in {@code outputOrdinates} the {@link Ordinate#Z} and {@link Ordinate#M}
+   *       values are included
+   * </ul>
+   *
+   * @param outputOrdinates a bit-pattern of ordinates to write.
+   * @param writer the output writer to append to.
+   * @throws IOException if an error occurs while using the writer.
+   */
+  private void appendOrdinateText(EnumSet<Ordinate> outputOrdinates, Writer writer)
+      throws IOException {
+
+    if (outputOrdinates.contains(Ordinate.Z)) writer.append(WKTConstants.Z);
+    if (outputOrdinates.contains(Ordinate.M)) writer.append(WKTConstants.M);
+  }
+
+  /**
+   * Appends all members of a <code>CoordinateSequence</code> to the stream. Each {@code Coordinate}
+   * is separated from another using a colon, the ordinates of a {@code Coordinate} are separated by
+   * a space.
+   *
+   * @param seq the <code>CoordinateSequence</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level
+   * @param indentFirst flag indicating that the first {@code Coordinate} of the sequence should be
+   *     indented for better visibility
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendSequenceText(
+      CoordinateSequence seq,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      boolean indentFirst,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (seq.size() == 0) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      if (indentFirst) indent(useFormatting, level, writer);
+      writer.write("(");
+      for (int i = 0; i < seq.size(); i++) {
+        if (i > 0) {
+          writer.write(", ");
+          if (coordsPerLine > 0 && i % coordsPerLine == 0) {
+            indent(useFormatting, level + 1, writer);
+          }
+        }
+        appendCoordinate(seq, outputOrdinates, i, writer, formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  /**
+   * Converts a <code>Polygon</code> to &lt;Polygon Text&gt; format, then appends it to the writer.
+   *
+   * @param polygon the <code>Polygon</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level
+   * @param indentFirst flag indicating that the first {@code Coordinate} of the sequence should be
+   *     indented for better visibility
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendPolygonText(
+      PolygonGeography polygon,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      boolean indentFirst,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (polygon == null || polygon.polygon.isEmpty()) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      if (indentFirst) indent(useFormatting, level, writer);
+      writer.write("(");
+      appendSequenceText(
+          polygon.getExteriorRing().getCoordinateSequence(),
+          outputOrdinates,
+          useFormatting,
+          level,
+          false,
+          writer,
+          formatter);
+      for (LineString hole : polygon.getLoops()) {
+        writer.write(", ");
+        appendSequenceText(
+            hole.getCoordinateSequence(),
+            outputOrdinates,
+            useFormatting,
+            level + 1,
+            true,
+            writer,
+            formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  /**
+   * Converts a <code>MultiPoint</code> to &lt;MultiPoint Text&gt; format, then appends it to the
+   * writer.
+   *
+   * @param multiPoint the <code>MultiPoint</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendMultiPointText(
+      PointGeography multiPoint,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (multiPoint.numShapes() == 0) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      writer.write("(");
+      CoordinateSequence sequence = multiPoint.getCoordinateSequence();
+      for (int i = 0; i < sequence.size(); i++) {
+        if (i > 0) {
+          writer.write(", ");
+          indentCoords(useFormatting, i, level + 1, writer);
+        }
+        appendSequenceText(
+            new SinglePointGeography(multiPoint.getPoints().get(i)).getCoordinateSequence(),
+            outputOrdinates,
+            useFormatting,
+            level,
+            false,
+            writer,
+            formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  /**
+   * Converts a <code>MultiLineString</code> to &lt;MultiLineString Text&gt; format, then appends it
+   * to the writer.
+   *
+   * @param multiLineString the <code>MultiLineString</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level //@param indentFirst flag indicating that the first {@code
+   *     Coordinate} of the sequence should be indented for // better visibility
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendMultiLineStringText(
+      PolylineGeography multiLineString,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level, /*boolean indentFirst, */
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (multiLineString.numShapes() == 0) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      int level2 = level;
+      boolean doIndent = false;
+      writer.write("(");
+      for (int i = 0; i < multiLineString.numShapes(); i++) {
+        if (i > 0) {
+          writer.write(", ");
+          level2 = level + 1;
+          doIndent = true;
+        }
+        appendSequenceText(
+            new SinglePolylineGeography(multiLineString.getPolylines().get(i))
+                .getCoordinateSequence(),
+            outputOrdinates,
+            useFormatting,
+            level2,
+            doIndent,
+            writer,
+            formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  /**
+   * Converts a <code>MultiPolygon</code> to &lt;MultiPolygon Text&gt; format, then appends it to
+   * the writer.
+   *
+   * @param multiPolygon the <code>MultiPolygon</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendMultiPolygonText(
+      MultiPolygonGeography multiPolygon,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (multiPolygon.numShapes() == 0) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      int level2 = level;
+      boolean doIndent = false;
+      writer.write("(");
+      for (int i = 0; i < multiPolygon.numShapes(); i++) {
+        if (i > 0) {
+          writer.write(", ");
+          level2 = level + 1;
+          doIndent = true;
+        }
+        appendPolygonText(
+            (PolygonGeography) multiPolygon.getFeatures().get(i),
+            outputOrdinates,
+            useFormatting,
+            level2,
+            doIndent,
+            writer,
+            formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  /**
+   * Converts a <code>GeometryCollection</code> to &lt;GeometryCollectionText&gt; format, then
+   * appends it to the writer.
+   *
+   * @param geometryCollection the <code>GeometryCollection</code> to process
+   * @param useFormatting flag indicating that
+   * @param level the indentation level
+   * @param writer the output writer to append to
+   * @param formatter the formatter to use for writing ordinate values.
+   */
+  private void appendGeometryCollectionText(
+      GeographyCollection geometryCollection,
+      EnumSet<Ordinate> outputOrdinates,
+      boolean useFormatting,
+      int level,
+      Writer writer,
+      OrdinateFormat formatter)
+      throws IOException {
+    if (geometryCollection.numShapes() == 0) {
+      writer.write(WKTConstants.EMPTY);
+    } else {
+      int level2 = level;
+      writer.write("(");
+      for (int i = 0; i < geometryCollection.numShapes(); i++) {
+        if (i > 0) {
+          writer.write(", ");
+          level2 = level + 1;
+        }
+        appendGeometryTaggedText(
+            geometryCollection.getFeatures().get(i),
+            outputOrdinates,
+            useFormatting,
+            level2,
+            writer,
+            formatter);
+      }
+      writer.write(")");
+    }
+  }
+
+  private void indentCoords(boolean useFormatting, int coordIndex, int level, Writer writer)
+      throws IOException {
+    if (coordsPerLine <= 0 || coordIndex % coordsPerLine != 0) return;
+    indent(useFormatting, level, writer);
+  }
+
+  private void indent(boolean useFormatting, int level, Writer writer) throws IOException {
+    if (!useFormatting || level <= 0) return;
+    writer.write("\n");
+    for (int i = 0; i < level; i++) {
+      writer.write(indentTabStr);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
+++ b/common/src/main/java/org/apache/sedona/common/utils/GeomUtils.java
@@ -195,12 +195,7 @@ public class GeomUtils {
     if (geometry == null) {
       return null;
     }
-    int endian =
-        ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
-            ? ByteOrderValues.BIG_ENDIAN
-            : ByteOrderValues.LITTLE_ENDIAN;
-    WKBWriter writer =
-        new WKBWriter(GeomUtils.getDimension(geometry), endian, geometry.getSRID() != 0);
+    WKBWriter writer = createWKBWriter(GeomUtils.getDimension(geometry), geometry.getSRID() != 0);
     return writer.write(geometry);
   }
 
@@ -208,12 +203,21 @@ public class GeomUtils {
     if (geometry == null) {
       return null;
     }
-    int endian =
-        ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
-            ? ByteOrderValues.BIG_ENDIAN
-            : ByteOrderValues.LITTLE_ENDIAN;
-    WKBWriter writer = new WKBWriter(GeomUtils.getDimension(geometry), endian, false);
+    WKBWriter writer = createWKBWriter(GeomUtils.getDimension(geometry), false);
     return writer.write(geometry);
+  }
+
+  private static final int NATIVE_WKB_BYTE_ORDER =
+      ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
+          ? ByteOrderValues.BIG_ENDIAN
+          : ByteOrderValues.LITTLE_ENDIAN;
+
+  public static WKBWriter createWKBWriter(int dimension, boolean includeSRID) {
+    return new WKBWriter(dimension, NATIVE_WKB_BYTE_ORDER, includeSRID);
+  }
+
+  public static WKBWriter createWKBWriter(int dimension) {
+    return createWKBWriter(dimension, false);
   }
 
   public static Geometry get2dGeom(Geometry geom) {

--- a/common/src/test/java/org/apache/sedona/common/S2Geography/WKBReaderTest.java
+++ b/common/src/test/java/org/apache/sedona/common/S2Geography/WKBReaderTest.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import com.google.common.geometry.S2Point;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.jts.io.ParseException;
+
+public class WKBReaderTest {
+  @Test
+  public void PointGeographyTest() throws ParseException {
+    // WKB for POINT (30 10), little-endian
+    byte[] wkb =
+        new byte[] {
+          0x01, // little endian
+          0x01,
+          0x00,
+          0x00,
+          0x00, // type = Point (1)
+          // X = 30.0
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x3E,
+          0x40,
+          // Y = 10.0
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x24,
+          0x40
+        };
+
+    WKBReader reader = new WKBReader();
+    S2Geography geo = reader.read(wkb);
+
+    // Kind should be POINT
+    Assert.assertEquals(S2Geography.GeographyKind.POINT, geo.kind);
+
+    // Extract the S2Point
+    S2Point p = geo.shape(0).chain(0).get(0);
+    Assert.assertNotNull(p);
+
+    // Convert to WKT via your TestHelper (or manually check coords)
+    String wkt = TestHelper.toPointWkt(p);
+    // The WKTWriter default formatting uses 6 decimal places
+    String expected = "POINT (30.000000 10.000000)";
+    Assert.assertEquals(expected, wkt);
+  }
+
+  @Test
+  public void PolylineGeographyTest() throws ParseException {
+    // WKB for LINESTRING (30 10, 12 42), little-endian
+    byte[] wkb =
+        new byte[] {
+          0x01, // little endian
+          0x02,
+          0x00,
+          0x00,
+          0x00, // type = LineString (2)
+          0x02,
+          0x00,
+          0x00,
+          0x00, // num points = 2
+          // Point 1: X = 30.0, Y = 10.0
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x3E,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x24,
+          0x40,
+          // Point 2: X = 12.0, Y = 42.0
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x28,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x45,
+          0x40
+        };
+
+    WKBReader reader = new WKBReader();
+    S2Geography geo = reader.read(wkb);
+
+    // Expect a POLYLINE geometry
+    Assert.assertEquals(S2Geography.GeographyKind.POLYLINE, geo.kind);
+
+    // Extract the two S2Points
+    List<S2Point> pts = geo.shape(0).chain(0);
+    Assert.assertEquals(2, pts.size());
+
+    // Check their WKT
+    String wkt1 = TestHelper.toPointWkt(pts.get(0));
+    String wkt2 = TestHelper.toPointWkt(pts.get(1));
+    Assert.assertEquals("POINT (30.000000 10.000000)", wkt1);
+    Assert.assertEquals("POINT (12.000000 42.000000)", wkt2);
+  }
+
+  @Test
+  public void PolygonGeographyTest() throws ParseException {
+    // WKB for POLYGON ((35 10,45 45,15 40,10 20,35 10),(20 30,35 35,30 20,20 30)), little-endian
+    byte[] wkb =
+        new byte[] {
+          0x01, // little endian
+          0x03,
+          0x00,
+          0x00,
+          0x00, // type = Polygon (3)
+          0x02,
+          0x00,
+          0x00,
+          0x00, // num rings = 2
+
+          // Ring 1: 5 points
+          0x05,
+          0x00,
+          0x00,
+          0x00,
+          // (35.0, 10.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x41,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x24,
+          0x40,
+          // (45.0, 45.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x46,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x46,
+          0x40,
+          // (15.0, 40.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x2E,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x44,
+          0x40,
+          // (10.0, 20.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x24,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x34,
+          0x40,
+          // (35.0, 10.0) closing
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x41,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x24,
+          0x40,
+
+          // Ring 2: 4 points
+          0x04,
+          0x00,
+          0x00,
+          0x00,
+          // (20.0, 30.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x34,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x3E,
+          0x40,
+          // (35.0, 35.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x41,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          (byte) 0x80,
+          0x41,
+          0x40,
+          // (30.0, 20.0)
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x3E,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x34,
+          0x40,
+          // (20.0, 30.0) closing
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x34,
+          0x40,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x3E,
+          0x40
+        };
+
+    WKBReader reader = new WKBReader();
+    S2Geography geo = reader.read(wkb);
+
+    // Expect a POLYGON geometry
+    Assert.assertEquals(S2Geography.GeographyKind.POLYGON, geo.kind);
+
+    // Outer ring: 4 points
+    List<S2Point> outer = geo.shape(0).chain(0);
+    Assert.assertEquals(4, outer.size());
+    Assert.assertEquals("POINT (35.000000 10.000000)", TestHelper.toPointWkt(outer.get(0)));
+    Assert.assertEquals("POINT (45.000000 45.000000)", TestHelper.toPointWkt(outer.get(1)));
+    Assert.assertEquals("POINT (15.000000 40.000000)", TestHelper.toPointWkt(outer.get(2)));
+    Assert.assertEquals("POINT (10.000000 20.000000)", TestHelper.toPointWkt(outer.get(3)));
+
+    // Hole ring: 3 points
+    List<S2Point> hole = geo.shape(0).chain(1);
+    Assert.assertEquals(3, hole.size());
+    Assert.assertEquals("POINT (20.000000 30.000000)", TestHelper.toPointWkt(hole.get(0)));
+    Assert.assertEquals("POINT (35.000000 35.000000)", TestHelper.toPointWkt(hole.get(1)));
+    Assert.assertEquals("POINT (30.000000 20.000000)", TestHelper.toPointWkt(hole.get(2)));
+  }
+
+  @Test
+  public void MultiPointTest() throws ParseException {
+    String hexStr =
+        "0104000000020000006901000000000000000000F03F000000000000F03F690100000000000000000000400000000000000040";
+    String wkt = "MULTIPOINT((1 1),(2 2))";
+    TestHelper.checkWKBGeography(hexStr, wkt);
+  }
+
+  @Test
+  public void MultiPolylineTest() throws ParseException {
+    String hexStr =
+        "0105000020E6100000020000000102000000020000000000000000000000000000000000F03F000000000000004000000000000008400102000000020000000000000000001040000000000000144000000000000018400000000000001C40";
+    String wkt = "MULTILINESTRING((0 1,2 3),(4 5,6 7))";
+    TestHelper.checkWKBGeography(hexStr, wkt);
+  }
+
+  @Test
+  public void MultiPolygonTest() throws ParseException {
+    String hexStr =
+        "0106000020E6100000020000000103000020E61000000200000005000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440000000000000244000000000000000000000000000000000000000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000002240000000000000224000000000000022400000000000002240000000000000F03F000000000000F03F000000000000F03F0103000020E6100000010000000500000000000000000022C0000000000000000000000000000022C00000000000002440000000000000F0BF0000000000002440000000000000F0BF000000000000000000000000000022C00000000000000000";
+    String multiPolygonWkt =
+        "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),((-9 0,-9 10,-1 10,-1 0,-9 0)))";
+    TestHelper.checkWKBGeography(hexStr, multiPolygonWkt);
+  }
+
+  @Test
+  public void CollectionGeographyTest() throws ParseException {
+    String hexStr =
+        "0107000020E6100000090000000101000020E61000000000000000000000000000000000F03F0101000020E61000000000000000000000000000000000F03F0101000020E6100000000000000000004000000000000008400102000020E61000000200000000000000000000400000000000000840000000000000104000000000000014400102000020E6100000020000000000000000000000000000000000F03F000000000000004000000000000008400102000020E6100000020000000000000000001040000000000000144000000000000018400000000000001C400103000020E61000000200000005000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440000000000000244000000000000000000000000000000000000000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000002240000000000000224000000000000022400000000000002240000000000000F03F000000000000F03F000000000000F03F0103000020E61000000200000005000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440000000000000244000000000000000000000000000000000000000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000002240000000000000224000000000000022400000000000002240000000000000F03F000000000000F03F000000000000F03F0103000020E6100000010000000500000000000000000022C0000000000000000000000000000022C00000000000002440000000000000F0BF0000000000002440000000000000F0BF000000000000000000000000000022C00000000000000000";
+    String geometryCollectionWkt =
+        "GEOMETRYCOLLECTION(POINT(0 1),POINT(0 1),POINT(2 3),LINESTRING(2 3,4 5),LINESTRING(0 1,2 3),LINESTRING(4 5,6 7),POLYGON((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),POLYGON((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),POLYGON((-9 0,-9 10,-1 10,-1 0,-9 0)))";
+    TestHelper.checkWKBGeography(hexStr, geometryCollectionWkt);
+  }
+
+  @Test
+  public void EmptyTest() throws ParseException {
+    TestHelper.checkWKBGeography("0101000000", "POINT EMPTY");
+    TestHelper.checkWKBGeography("010300000000000000", "POLYGON EMPTY");
+    TestHelper.checkWKBGeography("010200000000000000", "LINESTRING EMPTY");
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/S2Geography/WKBWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/S2Geography/WKBWriterTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.geometry.S2LatLng;
+import com.google.common.geometry.S2Point;
+import com.google.common.geometry.S2Polyline;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.locationtech.jts.io.ByteOrderValues;
+import org.locationtech.jts.io.ParseException;
+
+public class WKBWriterTest {
+
+  @Test
+  public void PointGeographyToHexTest() throws IOException, ParseException {
+    // 1) create an S2Point at (lat=10, lon=30)
+    S2Point s2Pt = S2LatLng.fromDegrees(10.0, 30.0).toPoint();
+    SinglePointGeography inputGeo = new SinglePointGeography(s2Pt);
+
+    // 2) write it to 2D little‐endian WKB
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(inputGeo);
+
+    // 3) read it back with WKBReader
+    WKBReader reader = new WKBReader();
+    PointGeography outputGeo = (PointGeography) reader.read(wkb);
+
+    // 4) extract the decoded S2Point + verify lat/lng round‐trip exactly
+    S2Point decoded = outputGeo.points.get(0);
+    S2LatLng decodedLL = S2LatLng.fromPoint(decoded);
+    assertEquals(10.0, decodedLL.latDegrees(), 1e-12);
+    assertEquals(30.0, decodedLL.lngDegrees(), 1e-12);
+  }
+
+  /** Same idea for a simple LINESTRING: hex-encode and compare. */
+  @Test
+  public void PolylineGeographyToHexTest() throws IOException, ParseException {
+    // 1) build a simple S2Polyline LINESTRING(30 10, 12 42)
+    List<S2Point> pts =
+        List.of(
+            S2LatLng.fromDegrees(10.0, 30.0).toPoint(), S2LatLng.fromDegrees(42.0, 12.0).toPoint());
+    SinglePolylineGeography inputLine = new SinglePolylineGeography(new S2Polyline(pts));
+
+    // 2) write it to 2D little‐endian WKB
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(inputLine);
+
+    // 3) read it back
+    WKBReader reader = new WKBReader();
+    PolylineGeography outputLine = (PolylineGeography) reader.read(wkb);
+
+    // 4) verify point‐by‐point round‐trip
+    List<S2Polyline> polylines = outputLine.getPolylines();
+    List<S2Point> decoded = new ArrayList<>();
+    for (S2Polyline polyline : polylines) {
+      decoded.addAll(polyline.vertices());
+    }
+    assertEquals(pts.size(), decoded.size());
+    for (int i = 0; i < pts.size(); i++) {
+      S2LatLng origLL = S2LatLng.fromPoint(pts.get(i));
+      S2LatLng decLL = S2LatLng.fromPoint(decoded.get(i));
+      assertEquals(origLL.latDegrees(), decLL.latDegrees(), 1e-12);
+      assertEquals(origLL.lngDegrees(), decLL.lngDegrees(), 1e-12);
+    }
+  }
+
+  @Test
+  public void MultiPointTest() throws ParseException, IOException {
+    String wkt = "MULTIPOINT ((10 40), (40 30))";
+    WKTReader reader = new WKTReader();
+    S2Geography geo = reader.read(wkt);
+
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(geo);
+    WKBReader readerWKB = new WKBReader();
+    S2Geography geoWKB = readerWKB.read(wkb);
+    assertEquals(0, TestHelper.compareTo(geo, geoWKB));
+  }
+
+  @Test
+  public void MultiPolylineTest() throws ParseException, IOException {
+    String wkt = "MULTILINESTRING((0 1,2 3),(4 5,6 7))";
+    WKTReader reader = new WKTReader();
+    S2Geography geo = reader.read(wkt);
+
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(geo);
+    WKBReader readerWKB = new WKBReader();
+    S2Geography geoWKB = readerWKB.read(wkb);
+    assertEquals(0, TestHelper.compareTo(geo, geoWKB));
+  }
+
+  @Test
+  public void MultiPolygonTest() throws ParseException, IOException {
+    String wkt =
+        "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),((-9 0,-9 10,-1 10,-1 0,-9 0)))";
+    WKTReader reader = new WKTReader();
+    S2Geography geo = reader.read(wkt);
+
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(geo);
+    WKBReader readerWKB = new WKBReader();
+    S2Geography geoWKB = readerWKB.read(wkb);
+    assertEquals(0, TestHelper.compareTo(geo, geoWKB));
+  }
+
+  @Test
+  public void CollectionTest() throws ParseException, IOException {
+    String wkt =
+        "GEOMETRYCOLLECTION(POINT(0 1),POINT(0 1),POINT(2 3),LINESTRING(2 3,4 5),LINESTRING(0 1,2 3),LINESTRING(4 5,6 7),POLYGON((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),POLYGON((0 0,0 10,10 10,10 0,0 0),(1 1,1 9,9 9,9 1,1 1)),POLYGON((-9 0,-9 10,-1 10,-1 0,-9 0)))";
+
+    WKTReader reader = new WKTReader();
+    S2Geography geo = reader.read(wkt);
+
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(geo);
+    WKBReader readerWKB = new WKBReader();
+    S2Geography geoWKB = readerWKB.read(wkb);
+    assertEquals(0, TestHelper.compareTo(geo, geoWKB));
+  }
+
+  @Test
+  public void emptyTest() throws ParseException, IOException {
+    String wkt = "POINT EMPTY";
+
+    WKTReader reader = new WKTReader();
+    S2Geography geo = reader.read(wkt);
+
+    WKBWriter writer = new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN);
+    byte[] wkb = writer.write(geo);
+    WKBReader readerWKB = new WKBReader();
+    S2Geography geoWKB = readerWKB.read(wkb);
+    assertEquals(0, TestHelper.compareTo(geo, geoWKB));
+  }
+}

--- a/common/src/test/java/org/apache/sedona/common/S2Geography/WKTReadWriterTest.java
+++ b/common/src/test/java/org/apache/sedona/common/S2Geography/WKTReadWriterTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sedona.common.S2Geography;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+
+public class WKTReadWriterTest {
+
+  private final WKTReader reader = new WKTReader() {};
+
+  private String writeWithPrecision(S2Geography geom, PrecisionModel pm) {
+    WKTWriter w = new WKTWriter();
+    w.setPrecisionModel(pm);
+    return w.write(geom);
+  }
+
+  @Test
+  public void significantDigits_defaultAndSingle() throws ParseException {
+    S2Geography geog = reader.read("POINT (0 3.333333333333334)");
+    String wkt = new WKTWriter().write(geog);
+    // default ≈16 digits
+    assertEquals("POINT (0 3.3333333333333344)", wkt);
+
+    // single‐precision ≈6 digits
+    assertEquals(
+        "POINT (0 3.333333)",
+        writeWithPrecision(geog, new PrecisionModel(PrecisionModel.FLOATING_SINGLE)));
+  }
+
+  @Test
+  public void lineString_roundTrip() throws ParseException {
+    String wkt = "LINESTRING (30 10, 10 30, 40 40)";
+    S2Geography g = reader.read(wkt);
+    assertEquals(wkt, writeWithPrecision(g, new PrecisionModel(PrecisionModel.FIXED)));
+  }
+
+  @Test
+  public void multilineString_roundTrip() throws ParseException {
+    String wkt = "MULTILINESTRING ((30 10, 10 30, 40 40), (30 10, 20 30, 40 40))";
+    S2Geography g = reader.read(wkt);
+    assertEquals(wkt, writeWithPrecision(g, new PrecisionModel(PrecisionModel.FIXED)));
+  }
+
+  @Test
+  public void polygon_roundTrip_simpleAndWithHole() throws ParseException {
+    String simple = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))";
+    assertEquals(
+        simple, writeWithPrecision(reader.read(simple), new PrecisionModel(PrecisionModel.FIXED)));
+
+    String withHole =
+        "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), " + "(20 30, 35 35, 30 20, 20 30))";
+    String expected =
+        "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), " + "(30 20, 35 35, 20 30, 30 20))";
+    PolygonGeography sp = (PolygonGeography) reader.read(withHole);
+    assertEquals(
+        expected,
+        writeWithPrecision(reader.read(withHole), new PrecisionModel(PrecisionModel.FIXED)));
+  }
+
+  @Test
+  public void multiGeometries_roundTrip() throws ParseException {
+    assertEquals(
+        "MULTIPOINT ((10 40), (40 30), (20 20), (30 10))",
+        writeWithPrecision(
+            reader.read("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))"),
+            new PrecisionModel(PrecisionModel.FIXED)));
+    assertEquals(
+        "MULTILINESTRING " + "((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",
+        writeWithPrecision(
+            reader.read(
+                "MULTILINESTRING " + "((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))"),
+            new PrecisionModel(PrecisionModel.FIXED)));
+    assertEquals(
+        "MULTIPOLYGON "
+            + "(((30 20, 45 40, 10 40, 30 20)), "
+            + "((15 5, 40 10, 10 20, 5 10, 15 5)))",
+        writeWithPrecision(
+            reader.read(
+                "MULTIPOLYGON "
+                    + "(((30 20, 45 40, 10 40, 30 20)), "
+                    + "((15 5, 40 10, 10 20, 5 10, 15 5)))"),
+            new PrecisionModel(PrecisionModel.FIXED)));
+  }
+
+  @Test
+  public void collection_roundTrip() throws ParseException {
+    String wkt =
+        "GEOMETRYCOLLECTION ("
+            + "POINT (40 10), "
+            + "LINESTRING (10 10, 20 20, 10 40), "
+            + "POLYGON ((40 40, 20 45, 45 30, 40 40))"
+            + ")";
+    assertEquals(
+        wkt, writeWithPrecision(reader.read(wkt), new PrecisionModel(PrecisionModel.FIXED)));
+  }
+
+  @Test
+  public void empty_roundTrip() throws ParseException {
+    String point = "POINT EMPTY";
+    assertEquals(
+        point, writeWithPrecision(reader.read(point), new PrecisionModel(PrecisionModel.FIXED)));
+    String line = "LINESTRING EMPTY";
+    assertEquals(
+        line, writeWithPrecision(reader.read(line), new PrecisionModel(PrecisionModel.FIXED)));
+    String polygon = "POLYGON EMPTY";
+    assertEquals(
+        polygon,
+        writeWithPrecision(reader.read(polygon), new PrecisionModel(PrecisionModel.FIXED)));
+    String multipoint = "MULTIPOINT EMPTY";
+    assertEquals(
+        multipoint,
+        writeWithPrecision(reader.read(multipoint), new PrecisionModel(PrecisionModel.FIXED)));
+    String multiline = "MULTILINESTRING EMPTY";
+    assertEquals(
+        multiline,
+        writeWithPrecision(reader.read(multiline), new PrecisionModel(PrecisionModel.FIXED)));
+    String multipolygon = "MULTIPOLYGON EMPTY";
+    assertEquals(
+        multipolygon,
+        writeWithPrecision(reader.read(multipolygon), new PrecisionModel(PrecisionModel.FIXED)));
+    String collection = "GEOMETRYCOLLECTION EMPTY";
+    assertEquals(
+        collection,
+        writeWithPrecision(reader.read(collection), new PrecisionModel(PrecisionModel.FIXED)));
+  }
+}

--- a/docs/community/vscode-development-guide.md
+++ b/docs/community/vscode-development-guide.md
@@ -1,0 +1,216 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+---
+
+layout: docs
+title: Apache Sedona VSCode Development Guide
+permalink: /community/vscode-development-guide/
+---
+
+Setting up Apache Sedona for Development in VSCode
+==================================================
+
+This guide provides comprehensive instructions for setting up your development environment for Apache Sedona using Visual Studio Code, focusing on Scala/Java development.
+
+Prerequisites
+-------------
+
+Ensure you have the following installed on your system:
+
+- **Java Development Kit (JDK) 8:** Apache Sedona currently targets JDK 8.
+
+  - **Installation:** Use your system's package manager (e.g., Homebrew on macOS: `brew install openjdk@8`) or download directly from Oracle/Adoptium.
+  - **`JAVA_HOME`:** Set your `JAVA_HOME` environment variable to point to your JDK 8 installation. For example, in your shell profile (`~/.zshrc`, `~/.bashrc`):
+
+    ```
+    export JAVA_HOME="/path/to/your/jdk8" # e.g., /opt/homebrew/opt/openjdk@8
+    export PATH="$JAVA_HOME/bin:$PATH"
+    ```
+
+- **Maven:** Apache Sedona uses Maven for dependency management and building.
+
+  - **Installation:** Install Maven via your package manager (e.g., `brew install maven`) or download from the Apache Maven website.
+
+- **Git:** For version control.
+
+Recommended VSCode Extensions
+-----------------------------
+
+Install the following extensions in VSCode to enhance your Scala/Java development experience.
+
+Extension Pack for Java (by Microsoft)
+--------------------------------------
+
+This pack bundles essential Java extensions, including:
+
+- Language Support for Java™ by Red Hat
+- Debugger for Java
+- Maven for Java
+- and others.
+
+[Install from VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack)
+
+Scala (Metals) (by Scala Metals)
+-------------------------------
+
+Provides rich language support for Scala.
+
+[Install from VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=scalameta.metals)
+
+Project Setup in VSCode
+-----------------------
+
+Clone Your Fork
+---------------
+
+If you haven't already, clone your fork of the Apache Sedona repository.
+
+```
+git clone https://github.com/<YourGitHubUsername>/sedona.git
+cd sedona
+```
+
+(Replace `<YourGitHubUsername>` with your actual GitHub username.)
+
+Open Project in VSCode
+----------------------
+
+Navigate your terminal into the `sedona` root directory and open the project.
+
+```
+code .
+```
+
+Maven Project Import
+--------------------
+
+Upon opening the folder, VSCode's "Maven for Java" extension should automatically detect the `pom.xml` files. You might see a prompt asking to import the Maven projects; accept this. If not, open the Maven sidebar (look for the Apache Maven icon, often an 'M' or an elephant head), expand the `sedona` project, and ensure all modules are loaded. A refresh button might be available if projects are not detected.
+
+*Initial warnings about missing packages (e.g., `The import org.apache.sedona.sql.utils cannot be resolved`) are common at this stage. A full Maven build, as described below, usually resolves these by downloading all necessary dependencies.*
+
+Building the Project
+--------------------
+
+You can build Apache Sedona using Maven directly from the VSCode integrated terminal.
+
+1. Open the integrated terminal in VSCode (`Terminal > New Terminal`).
+
+2. Run a full Maven build.
+
+```
+mvn clean install -DskipTests
+```
+
+- `mvn clean install`: Cleans previous builds, compiles the project, runs unit tests (if `-DskipTests` is not used), and installs artifacts to your local Maven repository.
+- `-DskipTests`: Skips running the unit tests, which significantly speeds up the build process for development purposes.
+
+For more detailed information on compiling Sedona, refer to the [Compile Sedona guide](https://sedona.apache.org/latest/community/develop/#run-all-unit-tests).
+
+Running Tests
+-------------
+
+Running Java Tests
+------------------
+
+VSCode's "Extension Pack for Java" provides excellent integration for running Java unit tests.
+
+1. From the editor: Open any Java test file (e.g., `core/src/test/java/org/apache/sedona/core/formatMapper/EarthdataRasterReaderTest.java`). You will see "Run Test" and "Debug Test" buttons above test methods and test classes. Click these to run or debug.
+
+2. Using the Test Explorer: Click the "Test" icon in the Activity Bar on the left (a beaker icon). This view lists all discovered tests. You can run all tests, or tests within a specific module or individual test.
+
+Running Scala Tests
+-------------------
+
+While the "Scala (Metals)" extension provides language support, direct integration into VSCode's Test Explorer for Scala tests might have limitations. The most reliable way to run Scala tests is via Maven.
+
+1. Run all Scala tests for a module: Open the integrated terminal and run Maven, specifying the module.
+
+```
+# Example for the 'sql' module's Scala tests
+mvn test -pl sql
+```
+
+2. Run a single Scala test file or test case via Maven: For more granular control, you can target specific Scala test classes or methods directly using Maven's surefire plugin.
+
+```
+# Example: Run a specific Scala test class within a module
+mvn test -pl <module_name> -Dtest=<YourScalaTestClassName>
+
+# Example: Run a specific method within a Scala test class
+mvn test -pl <module_name> -Dtest=<YourScalaTestClassName>#<yourTestMethodName>
+```
+
+(Replace `<module_name>`, `<YourScalaTestClassName>`, and `<yourTestMethodName>` with actual values from the Sedona codebase, e.g., `sql`, `TestPredicate`, `test_st_contains`.)
+
+Addressing Common Issues
+------------------------
+
+The import org.apache.sedona.sql.utils cannot be resolved
+--------------------------------------------------------
+
+This error often occurs because VSCode's Java Language Server hasn't fully picked up the project's compiled artifacts and dependencies.
+
+- Solution 1: Clean Build and Reload Workspace
+
+    1. Perform a clean Maven build.
+
+    ```
+    mvn clean install -DskipTests
+    ```
+
+    2. In VSCode, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`), type "Java: Clean Java Language Server Workspace" and select the command. Then, restart VSCode if prompted.
+
+- Solution 2: Maven Update
+
+  In the Maven sidebar, try clicking the "Reload All Maven Projects" button (refresh icon).
+
+package sun.misc does not exist (when using Java 11+)
+-----------------------------------------------------
+
+If you encounter this error, usually when running tests with JDK >8, it's due to how newer JDKs handle internal APIs.
+
+- Solution: In your IDE settings, ensure you're explicitly using JDK 8 for this project or pass appropriate JVM arguments if running with a higher JDK (e.g., `--add-exports`). You may also need to disable the option "Use '--release' option for cross-compilation" if available.
+
+Debugging
+---------
+
+Java Debugging
+--------------
+
+1. Set Breakpoints: Click in the gutter (left margin) of your Java code to set breakpoints.
+
+2. Start Debugging:
+    - Click the "Run and Debug" icon in the Activity Bar.
+    - Click "Run and Debug" or use the "Debug Test" buttons.
+    - VSCode will create a debug configuration if none exists.
+
+Scala Debugging
+---------------
+
+The "Scala (Metals)" extension supports debugging. You might need to create a `launch.json` configuration for specific debugging scenarios.
+
+- Steps:
+    1. Open the "Run and Debug" view.
+    2. Click "create a launch.json file".
+    3. Select "Metals" or "Java" as the environment.
+    4. Configure `launch.json` for your specific test or application.
+    - For detailed Scala debugging setup with Metals, refer to the [Metals documentation](https://scalameta.org/metals/docs/editors/vscode/#run-and-debug).
+
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
       - Contributor Guide:
           - Rules: community/rule.md
           - Develop: community/develop.md
+          - VSCode Development: community/vscode-development-guide.md
       - Committer Guide:
           - Project Management Committee: community/contributor.md
           - Become a release manager: community/release-manager.md

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,7 @@
         <spark.compat.version>3.4</spark.compat.version>
         <spark.major.version>3</spark.major.version>
         <log4j.version>2.19.0</log4j.version>
-        <graphframe.version>0.8.3-spark3.4</graphframe.version>
-
+        <graphframes.version>0.9.2</graphframes.version>
         <flink.version>1.19.0</flink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <googles2.version>20250620-rc1</googles2.version>
@@ -607,7 +606,6 @@
                         <spark.version>${spark.version}</spark.version>
                         <scala.version>${scala.version}</scala.version>
                         <log4j.version>${log4j.version}</log4j.version>
-                        <graphframe.version>${graphframe.version}</graphframe.version>
                     </properties>
                 </configuration>
                 <executions>
@@ -715,7 +713,6 @@
                 <spark.version>3.4.0</spark.version>
                 <spark.compat.version>3.4</spark.compat.version>
                 <log4j.version>2.19.0</log4j.version>
-                <graphframe.version>0.8.3-spark3.4</graphframe.version>
                 <!-- Skip deploying parent module. it will be deployed with sedona-spark-3.3 -->
                 <skip.deploy.common.modules>true</skip.deploy.common.modules>
             </properties>
@@ -732,7 +729,6 @@
                 <spark.version>3.5.0</spark.version>
                 <spark.compat.version>3.5</spark.compat.version>
                 <log4j.version>2.20.0</log4j.version>
-                <graphframe.version>0.8.3-spark3.5</graphframe.version>
                 <!-- Skip deploying parent module. it will be deployed with sedona-spark-3.3 -->
                 <skip.deploy.common.modules>true</skip.deploy.common.modules>
             </properties>
@@ -752,9 +748,10 @@
                 <hadoop.version>3.4.1</hadoop.version>
                 <log4j.version>2.24.3</log4j.version>
                 <slf4j.version>2.0.16</slf4j.version>
-                <graphframe.version>0.8.3-spark3.5</graphframe.version>
+
                 <scala.version>2.13.12</scala.version>
                 <scala.compat.version>2.13</scala.compat.version>
+
                 <!-- Skip deploying parent module. it will be deployed with sedona-spark-3.3 -->
                 <skip.deploy.common.modules>true</skip.deploy.common.modules>
             </properties>

--- a/python/sedona/__init__.py
+++ b/python/sedona/__init__.py
@@ -14,7 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 
+warnings.warn(
+    "The 'sedona' package structure has been reorganized. Please update your imports to use 'sedona.spark' prefix instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 from .version import version
 
 __all__ = ["version"]

--- a/python/sedona/core/SpatialRDD/__init__.py
+++ b/python/sedona/core/SpatialRDD/__init__.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.SpatialRDD import CircleRDD, PolygonRDD, PointRDD, RectangleRDD
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.SpatialRDD' is deprecated. Please use 'sedona.spark.core.SpatialRDD' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["CircleRDD", "PolygonRDD", "PointRDD", "RectangleRDD"]

--- a/python/sedona/core/__init__.py
+++ b/python/sedona/core/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/core/enums/__init__.py
+++ b/python/sedona/core/enums/__init__.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.enums import FileDataSplitter, GridType, IndexType
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.enums' is deprecated. Please use 'sedona.spark.core.enums' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["FileDataSplitter", "GridType", "IndexType"]

--- a/python/sedona/core/formatMapper/__init__.py
+++ b/python/sedona/core/formatMapper/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/core/formatMapper/geo_json_reader.py
+++ b/python/sedona/core/formatMapper/geo_json_reader.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.formatMapper.geo_json_reader import GeoJsonReader
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.formatMapper.geo_json_reader' is deprecated. Please use 'sedona.spark.core.formatMapper.geo_json_reader' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["GeoJsonReader"]

--- a/python/sedona/core/formatMapper/shapefileParser/__init__.py
+++ b/python/sedona/core/formatMapper/shapefileParser/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/core/formatMapper/shapefileParser/shape_file_reader.py
+++ b/python/sedona/core/formatMapper/shapefileParser/shape_file_reader.py
@@ -16,13 +16,14 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.formatMapper.shapefileParser.shape_file_reader import (
+    ShapefileReader,
+)
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.formatMapper.shapefileParser.shape_file_reader' is deprecated. Please use 'sedona.spark.core.formatMapper.shapefileParser.shape_file_reader' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["ShapefileReader"]

--- a/python/sedona/core/geom/__init__.py
+++ b/python/sedona/core/geom/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/core/geom/circle.py
+++ b/python/sedona/core/geom/circle.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.geom.circle import Circle
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.geom.circle' is deprecated. Please use 'sedona.spark.core.geom.circle' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["Circle"]

--- a/python/sedona/core/geom/envelope.py
+++ b/python/sedona/core/geom/envelope.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.geom.envelope import Envelope
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.geom.envelope' is deprecated. Please use 'sedona.spark.core.geom.envelope' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["Envelope"]

--- a/python/sedona/core/geom/geography.py
+++ b/python/sedona/core/geom/geography.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.geom.geography import Geography
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.geom.geography' is deprecated. Please use 'sedona.spark.core.geom.geography' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["Geography"]

--- a/python/sedona/core/jvm/__init__.py
+++ b/python/sedona/core/jvm/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/core/jvm/config.py
+++ b/python/sedona/core/jvm/config.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.jvm.config import is_greater_or_equal_version
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.jvm.config' is deprecated. Please use 'sedona.spark.core.jvm.config' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["is_greater_or_equal_version"]

--- a/python/sedona/core/spatialOperator/__init__.py
+++ b/python/sedona/core/spatialOperator/__init__.py
@@ -16,13 +16,17 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.core.spatialOperator import (
+    JoinQuery,
+    JoinQueryRaw,
+    KNNQuery,
+    RangeQuery,
+)
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.core.spatialOperator' is deprecated. Please use 'sedona.spark.core.spatialOperator' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["JoinQuery", "JoinQueryRaw", "KNNQuery", "RangeQuery"]

--- a/python/sedona/geopandas/__init__.py
+++ b/python/sedona/geopandas/__init__.py
@@ -24,3 +24,5 @@ from sedona.geopandas.geoseries import GeoSeries
 from sedona.geopandas.geodataframe import GeoDataFrame
 
 from sedona.geopandas.tools import sjoin
+
+from sedona.geopandas.io import read_file

--- a/python/sedona/geopandas/base.py
+++ b/python/sedona/geopandas/base.py
@@ -25,9 +25,11 @@ from typing import (
     Optional,
     Union,
 )
+from shapely.geometry.base import BaseGeometry
 
 import geopandas as gpd
 import pandas as pd
+import pyspark.pandas as ps
 from pyspark.pandas._typing import (
     Axis,
     Dtype,
@@ -45,10 +47,6 @@ class GeoFrame(metaclass=ABCMeta):
     A base class for both GeoDataFrame and GeoSeries.
     """
 
-    @abstractmethod
-    def __getitem__(self, key: Any) -> Any:
-        raise NotImplementedError("This method is not implemented yet.")
-
     def _reduce_for_geostat_function(
         self,
         sfun: Callable[["GeoSeries"], Column],
@@ -60,248 +58,2074 @@ class GeoFrame(metaclass=ABCMeta):
     ) -> Union["GeoSeries", Scalar]:
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
-    def to_geopandas(self) -> Union[gpd.GeoDataFrame, pd.Series]:
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @abstractmethod
-    def _to_geopandas(self) -> Union[gpd.GeoDataFrame, pd.Series]:
-        raise NotImplementedError("This method is not implemented yet.")
-
     @property
-    @abstractmethod
     def sindex(self) -> "SpatialIndex":
-        raise NotImplementedError("This method is not implemented yet.")
+        """
+        Returns a spatial index built from the geometries.
 
-    @abstractmethod
+        Returns
+        -------
+        SpatialIndex
+            The spatial index for this GeoDataFrame.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> from sedona.geopandas import GeoDataFrame
+        >>>
+        >>> gdf = GeoDataFrame([{"geometry": Point(1, 1), "value": 1},
+        ...                     {"geometry": Point(2, 2), "value": 2}])
+        >>> index = gdf.sindex
+        >>> index.size
+        2
+        """
+        # We pass in self.geometry here to use the active geometry column for dataframe
+        return _delegate_to_geometry_column("sindex", self.geometry)
+
     def copy(self: GeoFrameLike) -> GeoFrameLike:
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
-    def area(self):
-        raise NotImplementedError("This method is not implemented yet.")
+    def area(self) -> ps.Series:
+        """
+        Returns a Series containing the area of each geometry in the GeoSeries expressed in the units of the CRS.
+
+        Returns
+        -------
+        Series
+            A Series containing the area of each geometry.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon
+        >>> from sedona.geopandas import GeoSeries
+
+        >>> gs = GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])])
+        >>> gs.area
+        0    1.0
+        1    4.0
+        dtype: float64
+        """
+        return _delegate_to_geometry_column("area", self)
 
     @property
-    @abstractmethod
-    def crs(self):
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @crs.setter
-    @abstractmethod
-    def crs(self, value):
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    @abstractmethod
     def geom_type(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """
+        Returns a series of strings specifying the geometry type of each geometry of each object.
+
+        Note: Unlike Geopandas, Sedona returns LineString instead of LinearRing.
+
+        Returns
+        -------
+        Series
+            A Series containing the geometry type of each geometry.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, Point
+        >>> from sedona.geopandas import GeoSeries
+
+        >>> gs = GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Point(0, 0)])
+        >>> gs.geom_type
+        0    POLYGON
+        1    POINT
+        dtype: object
+        """
+        return _delegate_to_geometry_column("geom_type", self)
 
     @property
-    @abstractmethod
     def type(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def length(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """
+        Returns a Series containing the length of each geometry in the GeoSeries.
+
+        In the case of a (Multi)Polygon it measures the length of its exterior (i.e. perimeter).
+
+        For a GeometryCollection it measures sums the values for each of the individual geometries.
+
+        Returns
+        -------
+        Series
+            A Series containing the length of each geometry.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon
+        >>> from sedona.geopandas import GeoSeries
+
+        >>> gs = GeoSeries([Point(0, 0), LineString([(0, 0), (1, 1)]), Polygon([(0, 0), (1, 0), (1, 1)]), GeometryCollection([Point(0, 0), LineString([(0, 0), (1, 1)]), Polygon([(0, 0), (1, 0), (1, 1)])])])
+        >>> gs.length
+        0    0.000000
+        1    1.414214
+        2    3.414214
+        3    4.828427
+        dtype: float64
+        """
+        return _delegate_to_geometry_column("length", self)
 
     @property
-    @abstractmethod
     def is_valid(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        geometries that are valid.
 
-    @abstractmethod
+        Examples
+        --------
+
+        An example with one invalid polygon (a bowtie geometry crossing itself)
+        and one missing geometry:
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         Polygon([(0,0), (1, 1), (1, 0), (0, 1)]),  # bowtie geometry
+        ...         Polygon([(0, 0), (2, 2), (2, 0)]),
+        ...         None
+        ...     ]
+        ... )
+        >>> s
+        0         POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1    POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))
+        2         POLYGON ((0 0, 2 2, 2 0, 0 0))
+        3                                   None
+        dtype: geometry
+
+        >>> s.is_valid
+        0     True
+        1    False
+        2     True
+        3    False
+        dtype: bool
+
+        See also
+        --------
+        GeoSeries.is_valid_reason : reason for invalidity
+        """
+        return _delegate_to_geometry_column("is_valid", self)
+
     def is_valid_reason(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``Series`` of strings with the reason for invalidity of
+        each geometry.
+
+        Examples
+        --------
+
+        An example with one invalid polygon (a bowtie geometry crossing itself)
+        and one missing geometry:
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         Polygon([(0,0), (1, 1), (1, 0), (0, 1)]),  # bowtie geometry
+        ...         Polygon([(0, 0), (2, 2), (2, 0)]),
+        ...         Polygon([(0, 0), (2, 0), (1, 1), (2, 2), (0, 2), (1, 1), (0, 0)]),
+        ...         None
+        ...     ]
+        ... )
+        >>> s
+        0         POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1    POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))
+        2         POLYGON ((0 0, 2 2, 2 0, 0 0))
+        3                                   None
+        dtype: geometry
+
+        >>> s.is_valid_reason()
+        0    Valid Geometry
+        1    Self-intersection at or near point (0.5, 0.5, NaN)
+        2    Valid Geometry
+        3    Ring Self-intersection at or near point (1.0, 1.0)
+        4    None
+        dtype: object
+
+        See also
+        --------
+        GeoSeries.is_valid : detect invalid geometries
+        GeoSeries.make_valid : fix invalid geometries
+        """
+        return _delegate_to_geometry_column("is_valid_reason", self)
 
     @property
-    @abstractmethod
     def is_empty(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """
+        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        empty geometries.
 
-    @abstractmethod
+        Examples
+        --------
+        An example of a GeoDataFrame with one empty point, one point and one missing
+        value:
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point
+        >>> geoseries = GeoSeries([Point(), Point(2, 1), None], crs="EPSG:4326")
+        >>> geoseries
+        0  POINT EMPTY
+        1  POINT (2 1)
+        2         None
+
+        >>> geoseries.is_empty
+        0     True
+        1    False
+        2    False
+        dtype: bool
+
+        See Also
+        --------
+        GeoSeries.isna : detect missing geometries
+        """
+        return _delegate_to_geometry_column("is_empty", self)
+
     def count_coordinates(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def count_geometries(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def count_interior_rings(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def is_simple(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        geometries that do not cross themselves.
+
+        This is meaningful only for `LineStrings` and `LinearRings`.
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import LineString
+        >>> s = GeoSeries(
+        ...     [
+        ...         LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
+        ...         LineString([(0, 0), (1, 1), (1, -1)]),
+        ...     ]
+        ... )
+        >>> s
+        0    LINESTRING (0 0, 1 1, 1 -1, 0 1)
+        1         LINESTRING (0 0, 1 1, 1 -1)
+        dtype: geometry
+
+        >>> s.is_simple
+        0    False
+        1     True
+        dtype: bool
+        """
+        return _delegate_to_geometry_column("is_simple", self)
 
     @property
-    @abstractmethod
     def is_ring(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def is_ccw(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def is_closed(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def has_z(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        features that have a z-component.
 
-    @abstractmethod
+        Notes
+        -----
+        Every operation in GeoPandas is planar, i.e. the potential third
+        dimension is not taken into account.
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Point(0, 1),
+        ...         Point(0, 1, 2),
+        ...     ]
+        ... )
+        >>> s
+        0        POINT (0 1)
+        1    POINT Z (0 1 2)
+        dtype: geometry
+
+        >>> s.has_z
+        0    False
+        1     True
+        dtype: bool
+        """
+        return _delegate_to_geometry_column("has_z", self)
+
     def get_precision(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def get_geometry(self, index):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns the n-th geometry from a collection of geometries (0-indexed).
+
+        If the index is non-negative, it returns the geometry at that index.
+        If the index is negative, it counts backward from the end of the collection (e.g., -1 returns the last geometry).
+        Returns None if the index is out of bounds.
+
+        Note: Simple geometries act as length-1 collections
+
+        Note: Using Shapely < 2.0, may lead to different results for empty simple geometries due to how
+        shapely interprets them.
+
+        Parameters
+        ----------
+        index : int or array_like
+            Position of a geometry to be retrieved within its collection
+
+        Returns
+        -------
+        GeoSeries
+
+        Notes
+        -----
+        Simple geometries act as collections of length 1. Any out-of-range index value
+        returns None.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, MultiPoint, GeometryCollection
+        >>> s = geopandas.GeoSeries(
+        ...     [
+        ...         Point(0, 0),
+        ...         MultiPoint([(0, 0), (1, 1), (0, 1), (1, 0)]),
+        ...         GeometryCollection(
+        ...             [MultiPoint([(0, 0), (1, 1), (0, 1), (1, 0)]), Point(0, 1)]
+        ...         ),
+        ...         Polygon(),
+        ...         GeometryCollection(),
+        ...     ]
+        ... )
+        >>> s
+        0                                          POINT (0 0)
+        1              MULTIPOINT ((0 0), (1 1), (0 1), (1 0))
+        2    GEOMETRYCOLLECTION (MULTIPOINT ((0 0), (1 1), ...
+        3                                        POLYGON EMPTY
+        4                             GEOMETRYCOLLECTION EMPTY
+        dtype: geometry
+
+        >>> s.get_geometry(0)
+        0                                POINT (0 0)
+        1                                POINT (0 0)
+        2    MULTIPOINT ((0 0), (1 1), (0 1), (1 0))
+        3                              POLYGON EMPTY
+        4                                       None
+        dtype: geometry
+
+        >>> s.get_geometry(1)
+        0           None
+        1    POINT (1 1)
+        2    POINT (0 1)
+        3           None
+        4           None
+        dtype: geometry
+
+        >>> s.get_geometry(-1)
+        0    POINT (0 0)
+        1    POINT (1 0)
+        2    POINT (0 1)
+        3  POLYGON EMPTY
+        4           None
+        dtype: geometry
+
+        """
+        return _delegate_to_geometry_column("get_geometry", self, index)
 
     @property
-    @abstractmethod
     def boundary(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``GeoSeries`` of lower dimensional objects representing
+        each geometry's set-theoretic `boundary`.
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (1, 1), (1, 0)]),
+        ...         Point(0, 0),
+        ...     ]
+        ... )
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1        LINESTRING (0 0, 1 1, 1 0)
+        2                       POINT (0 0)
+        dtype: geometry
+
+        >>> s.boundary
+        0    LINESTRING (0 0, 1 1, 0 1, 0 0)
+        1          MULTIPOINT ((0 0), (1 0))
+        2           GEOMETRYCOLLECTION EMPTY
+        dtype: geometry
+
+        See also
+        --------
+        GeoSeries.exterior : outer boundary (without interior rings)
+
+        """
+        return _delegate_to_geometry_column("boundary", self)
 
     @property
-    @abstractmethod
     def centroid(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``GeoSeries`` of points representing the centroid of each
+        geometry.
 
-    @abstractmethod
+        Note that centroid does not have to be on or within original geometry.
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (1, 1), (1, 0)]),
+        ...         Point(0, 0),
+        ...     ]
+        ... )
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1        LINESTRING (0 0, 1 1, 1 0)
+        2                       POINT (0 0)
+        dtype: geometry
+
+        >>> s.centroid
+        0    POINT (0.33333 0.66667)
+        1        POINT (0.70711 0.5)
+        2                POINT (0 0)
+        dtype: geometry
+
+        See also
+        --------
+        GeoSeries.representative_point : point guaranteed to be within each geometry
+        """
+        return _delegate_to_geometry_column("centroid", self)
+
     def concave_hull(self, ratio=0.0, allow_holes=False):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def convex_hull(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def delaunay_triangles(self, tolerance=0.0, only_edges=False):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def voronoi_polygons(self, tolerance=0.0, extend_to=None, only_edges=False):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def envelope(self):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``GeoSeries`` of geometries representing the envelope of
+        each geometry.
 
-    @abstractmethod
+        The envelope of a geometry is the bounding rectangle. That is, the
+        point or smallest rectangular polygon (with sides parallel to the
+        coordinate axes) that contains the geometry.
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (1, 1), (1, 0)]),
+        ...         MultiPoint([(0, 0), (1, 1)]),
+        ...         Point(0, 0),
+        ...     ]
+        ... )
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1        LINESTRING (0 0, 1 1, 1 0)
+        2         MULTIPOINT ((0 0), (1 1))
+        3                       POINT (0 0)
+        dtype: geometry
+
+        >>> s.envelope
+        0    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+        1    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+        2    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+        3                            POINT (0 0)
+        dtype: geometry
+
+        See also
+        --------
+        GeoSeries.convex_hull : convex hull geometry
+        """
+        return _delegate_to_geometry_column("envelope", self)
+
     def minimum_rotated_rectangle(self):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def exterior(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def extract_unique_points(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def offset_curve(self, distance, quad_segs=8, join_style="round", mitre_limit=5.0):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def interiors(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def remove_repeated_points(self, tolerance=0.0):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def set_precision(self, grid_size, mode="valid_output"):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def representative_point(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def minimum_bounding_circle(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def minimum_bounding_radius(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def minimum_clearance(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def normalize(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
-    def make_valid(self):
-        raise NotImplementedError("This method is not implemented yet.")
+    def make_valid(self, *, method="linework", keep_collapsed=True):
+        """Repairs invalid geometries.
 
-    @abstractmethod
+        Returns a ``GeoSeries`` with valid geometries.
+
+        If the input geometry is already valid, then it will be preserved.
+        In many cases, in order to create a valid geometry, the input
+        geometry must be split into multiple parts or multiple geometries.
+        If the geometry must be split into multiple parts of the same type
+        to be made valid, then a multi-part geometry will be returned
+        (e.g. a MultiPolygon).
+        If the geometry must be split into multiple parts of different types
+        to be made valid, then a GeometryCollection will be returned.
+
+        In Sedona, only the 'structure' method is available:
+
+        * the 'structure' algorithm tries to reason from the structure of the
+          input to find the 'correct' repair: exterior rings bound area,
+          interior holes exclude area. It first makes all rings valid, then
+          shells are merged and holes are subtracted from the shells to
+          generate valid result. It assumes that holes and shells are correctly
+          categorized in the input geometry.
+
+        Parameters
+        ----------
+        method : {'linework', 'structure'}, default 'linework'
+            Algorithm to use when repairing geometry. Sedona Geopandas only supports the 'structure' method.
+            The default method is "linework" to match compatibility with Geopandas, but it must be explicitly set to
+            'structure' to use the Sedona implementation.
+
+        keep_collapsed : bool, default True
+            For the 'structure' method, True will keep components that have
+            collapsed into a lower dimensionality. For example, a ring
+            collapsing to a line, or a line collapsing to a point.
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import MultiPolygon, Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)]),
+        ...         Polygon([(0, 2), (0, 1), (2, 0), (0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (1, 1), (1, 0)]),
+        ...     ],
+        ... )
+        >>> s
+        0    POLYGON ((0 0, 0 2, 1 1, 2 2, 2 0, 1 1, 0 0))
+        1              POLYGON ((0 2, 0 1, 2 0, 0 0, 0 2))
+        2                       LINESTRING (0 0, 1 1, 1 0)
+        dtype: geometry
+
+        >>> s.make_valid()
+        0    MULTIPOLYGON (((1 1, 0 0, 0 2, 1 1)), ((2 0, 1...
+        1                       POLYGON ((0 1, 2 0, 0 0, 0 1))
+        2                           LINESTRING (0 0, 1 1, 1 0)
+        dtype: geometry
+        """
+        return _delegate_to_geometry_column(
+            "make_valid", self, method=method, keep_collapsed=keep_collapsed
+        )
+
     def reverse(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def segmentize(self, max_segment_length):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def transform(self, transformation, include_z=False):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def force_2d(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def force_3d(self, z=0):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def line_merge(self, directed=False):
         raise NotImplementedError("This method is not implemented yet.")
 
     @property
-    @abstractmethod
     def unary_union(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
-    def union_all(self, method="unary", grid_size=None):
-        raise NotImplementedError("This method is not implemented yet.")
+    def union_all(self, method="unary", grid_size=None) -> BaseGeometry:
+        """Returns a geometry containing the union of all geometries in the
+        ``GeoSeries``.
 
-    @abstractmethod
+        Sedona does not support the method or grid_size argument, so the user does not need to manually
+        decide the algorithm being used.
+
+        Parameters
+        ----------
+        method : str (default ``"unary"``)
+            Not supported in Sedona.
+
+        grid_size : float, default None
+            Not supported in Sedona.
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import box
+        >>> s = GeoSeries([box(0, 0, 1, 1), box(0, 0, 2, 2)])
+        >>> s
+        0    POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))
+        1    POLYGON ((2 0, 2 2, 0 2, 0 0, 2 0))
+        dtype: geometry
+
+        >>> s.union_all()
+        <POLYGON ((0 1, 0 2, 2 2, 2 0, 1 0, 0 0, 0 1))>
+        """
+        return _delegate_to_geometry_column("union_all", self, method, grid_size)
+
+    def crosses(self, other, align=None) -> ps.Series:
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that cross `other`.
+
+        An object is said to cross `other` if its `interior` intersects the
+        `interior` of the other but does not contain it, and the dimension of
+        the intersection is less than the dimension of the one or the other.
+
+        Note: Unlike Geopandas, Sedona's implementation always return NULL when GeometryCollection is involved.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            crossed.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1             LINESTRING (0 0, 2 2)
+        2             LINESTRING (2 0, 0 2)
+        3                       POINT (0 1)
+        dtype: geometry
+        >>> s2
+        1    LINESTRING (1 0, 1 3)
+        2    LINESTRING (2 0, 0 2)
+        3              POINT (1 1)
+        4              POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries crosses a single
+        geometry:
+
+        >>> line = LineString([(-1, 1), (3, 1)])
+        >>> s.crosses(line)
+        0     True
+        1     True
+        2     True
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.crosses(s2, align=True)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.crosses(s2, align=False)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        Notice that a line does not cross a point that it contains.
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``crosses`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.disjoint
+        GeoSeries.intersects
+
+        """
+        return _delegate_to_geometry_column("crosses", self, other, align)
+
+    def intersects(self, other, align=None):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that intersects `other`.
+
+        An object is said to intersect `other` if its `boundary` and `interior`
+        intersects in any way with those of the other.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            intersected.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1             LINESTRING (0 0, 2 2)
+        2             LINESTRING (2 0, 0 2)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    LINESTRING (1 0, 1 3)
+        2    LINESTRING (2 0, 0 2)
+        3              POINT (1 1)
+        4              POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries crosses a single
+        geometry:
+
+        >>> line = LineString([(-1, 1), (3, 1)])
+        >>> s.intersects(line)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.intersects(s2, align=True)
+        0    False
+        1     True
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.intersects(s2, align=False)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``crosses`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.disjoint
+        GeoSeries.crosses
+        GeoSeries.touches
+        GeoSeries.intersection
+        """
+        return _delegate_to_geometry_column("intersects", self, other, align)
+
+    def overlaps(self, other, align=None):
+        """Returns True for all aligned geometries that overlap other, else False.
+
+        In the original Geopandas, Geometries overlap if they have more than one but not all
+        points in common, have the same dimension, and the intersection of the
+        interiors of the geometries has the same dimension as the geometries
+        themselves.
+
+        However, in Sedona, we return True in the case where the geometries points match.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if
+            overlaps.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         MultiPoint([(0, 0), (0, 1)]),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (0, 2)]),
+        ...         LineString([(0, 1), (1, 1)]),
+        ...         LineString([(1, 1), (3, 3)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+
+        We can check if each geometry of GeoSeries overlaps a single
+        geometry:
+
+        >>> polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        >>> s.overlaps(polygon)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We align both GeoSeries
+        based on index values and compare elements with the same index.
+
+        >>> s.overlaps(s2)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.overlaps(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3    False
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``overlaps`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.crosses
+        GeoSeries.intersects
+
+        """
+        return _delegate_to_geometry_column("overlaps", self, other, align)
+
+    def touches(self, other, align=None):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that touches `other`.
+
+        An object is said to touch `other` if it has at least one point in
+        common with `other` and its interior does not intersect with any part
+        of the other. Overlapping features therefore do not touch.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            touched.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         MultiPoint([(0, 0), (0, 1)]),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (-2, 0), (0, -2)]),
+        ...         LineString([(0, 1), (1, 1)]),
+        ...         LineString([(1, 1), (3, 0)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3         MULTIPOINT ((0 0), (0 1))
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, -2 0, 0 -2, 0 0))
+        2               LINESTRING (0 1, 1 1)
+        3               LINESTRING (1 1, 3 0)
+        4                         POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries touches a single
+        geometry:
+
+        >>> line = LineString([(0, 0), (-1, -2)])
+        >>> s.touches(line)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.touches(s2, align=True)
+        0    False
+        1     True
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.touches(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3    False
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``touches`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.overlaps
+        GeoSeries.intersects
+
+        """
+        return _delegate_to_geometry_column("touches", self, other, align)
+
+    def within(self, other, align=None):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is within `other`.
+
+        An object is said to be within `other` if at least one of its points is located
+        in the `interior` and no points are located in the `exterior` of the other.
+        If either object is empty, this operation returns ``False``.
+
+        This is the inverse of `contains` in the sense that the
+        expression ``a.within(b) == b.contains(a)`` always evaluates to
+        ``True``.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections and for geometries that are equal.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if each
+            geometry is within.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 1 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 0 2)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (0 0, 0 2)
+        3             LINESTRING (0 0, 0 1)]
+        4                       POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries is within a single
+        geometry:
+
+        >>> polygon = Polygon([(0, 0), (2, 2), (0, 2)])
+        >>> s.within(polygon)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s2.within(s)
+        0    False
+        1    False
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s2.within(s, align=False)
+        1     True
+        2    False
+        3     True
+        4     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is ``within`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.contains
+        """
+        return _delegate_to_geometry_column("within", self, other, align)
+
+    def covers(self, other, align=None):
+        """
+        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is entirely covering `other`.
+
+        An object A is said to cover another object B if no points of B lie
+        in the exterior of A.
+        If either object is empty, this operation returns ``False``.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+        Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        See
+        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+        for reference.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to check is being covered.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         LineString([(1, 1), (1.5, 1.5)]),
+        ...         Point(0, 0),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        1         POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2                  LINESTRING (0 0, 2 2)
+        3                            POINT (0 0)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        2                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        3                            LINESTRING (1 1, 1.5 1.5)
+        4                                          POINT (0 0)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries covers a single
+        geometry:
+
+        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        >>> s.covers(poly)
+        0     True
+        1    False
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.covers(s2, align=True)
+        0    False
+        1    False
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.covers(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``covers`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.covered_by
+        GeoSeries.overlaps
+        """
+        return _delegate_to_geometry_column("covers", self, other, align)
+
+    def covered_by(self, other, align=None):
+        """
+        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is entirely covered by `other`.
+
+        An object A is said to cover another object B if no points of B lie
+        in the exterior of A.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+        Sedona's behavior may differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        See
+        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+        for reference.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to check is being covered.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         LineString([(1, 1), (1.5, 1.5)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         Point(0, 0),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        1                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        2                            LINESTRING (1 1, 1.5 1.5)
+        3                                          POINT (0 0)
+        dtype: geometry
+        >>>
+
+        >>> s2
+        1    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        2         POLYGON ((0 0, 2 2, 0 2, 0 0))
+        3                  LINESTRING (0 0, 2 2)
+        4                            POINT (0 0)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries is covered by a single
+        geometry:
+
+        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        >>> s.covered_by(poly)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.covered_by(s2, align=True)
+        0    False
+        1     True
+        2     True
+        3     True
+        4    False
+        dtype: bool
+
+        >>> s.covered_by(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is ``covered_by`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.covers
+        GeoSeries.overlaps
+        """
+        return _delegate_to_geometry_column("covered_by", self, other, align)
+
+    def distance(self, other, align=None):
+        """Returns a ``Series`` containing the distance to aligned `other`.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            distance to.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (float)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 0), (1, 1)]),
+        ...         Polygon([(0, 0), (-1, 0), (-1, 1)]),
+        ...         LineString([(1, 1), (0, 0)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Point(3, 1),
+        ...         LineString([(1, 0), (2, 0)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0      POLYGON ((0 0, 1 0, 1 1, 0 0))
+        1    POLYGON ((0 0, -1 0, -1 1, 0 0))
+        2               LINESTRING (1 1, 0 0)
+        3                         POINT (0 0)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        2                                          POINT (3 1)
+        3                                LINESTRING (1 0, 2 0)
+        4                                          POINT (0 1)
+        dtype: geometry
+
+        We can check the distance of each geometry of GeoSeries to a single
+        geometry:
+
+        >>> point = Point(-1, 0)
+        >>> s.distance(point)
+        0    1.0
+        1    0.0
+        2    1.0
+        3    1.0
+        dtype: float64
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and use elements with the same index using
+        ``align=True`` or ignore index and use elements based on their matching
+        order using ``align=False``:
+
+        >>> s.distance(s2, align=True)
+        0         NaN
+        1    0.707107
+        2    2.000000
+        3    1.000000
+        4         NaN
+        dtype: float64
+
+        >>> s.distance(s2, align=False)
+        0    0.000000
+        1    3.162278
+        2    0.707107
+        3    1.000000
+        dtype: float64
+        """
+        return _delegate_to_geometry_column("distance", self, other, align)
+
+    def intersection(self, other, align=None):
+        """Returns a ``GeoSeries`` of the intersection of points in each
+        aligned geometry with `other`.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            intersection with.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        GeoSeries
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 6),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (1 0, 1 3)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (1 1)
+        5                       POINT (0 1)
+        dtype: geometry
+
+        We can also do intersection of each geometry and a single
+        shapely geometry:
+
+        >>> s.intersection(Polygon([(0, 0), (1, 1), (0, 1)]))
+        0    POLYGON ((0 0, 0 1, 1 1, 0 0))
+        1    POLYGON ((0 0, 0 1, 1 1, 0 0))
+        2             LINESTRING (0 0, 1 1)
+        3                       POINT (1 1)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.intersection(s2, align=True)
+        0                              None
+        1    POLYGON ((0 0, 0 1, 1 1, 0 0))
+        2                       POINT (1 1)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT EMPTY
+        5                              None
+        dtype: geometry
+
+        >>> s.intersection(s2, align=False)
+        0    POLYGON ((0 0, 0 1, 1 1, 0 0))
+        1             LINESTRING (1 1, 1 2)
+        2                       POINT (1 1)
+        3                       POINT (1 1)
+        4                       POINT (0 1)
+        dtype: geometry
+
+
+        See Also
+        --------
+        GeoSeries.difference
+        GeoSeries.symmetric_difference
+        GeoSeries.union
+        """
+        return _delegate_to_geometry_column("intersection", self, other, align)
+
+    def snap(self, other, tolerance, align=None):
+        """Snap the vertices and segments of the geometry to vertices of the reference.
+
+        Vertices and segments of the input geometry are snapped to vertices of the
+        reference geometry, returning a new geometry; the input geometries are not
+        modified. The result geometry is the input geometry with the vertices and
+        segments snapped. If no snapping occurs then the input geometry is returned
+        unchanged. The tolerance is used to control where snapping is performed.
+
+        Where possible, this operation tries to avoid creating invalid geometries;
+        however, it does not guarantee that output geometries will be valid. It is
+        the responsibility of the caller to check for and handle invalid geometries.
+
+        Because too much snapping can result in invalid geometries being created,
+        heuristics are used to determine the number and location of snapped
+        vertices that are likely safe to snap. These heuristics may omit
+        some potential snaps that are otherwise within the tolerance.
+
+        Note: Sedona's result may differ slightly from geopandas's snap() result
+        because of small differences between the underlying engines being used.
+
+        The operation works in a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The Geoseries (elementwise) or geometric object to snap to.
+        tolerance : float or array like
+            Maximum distance between vertices that shall be snapped
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        GeoSeries
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Point(0.5, 2.5),
+        ...         LineString([(0.1, 0.1), (0.49, 0.51), (1.01, 0.89)]),
+        ...         Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]),
+        ...     ],
+        ... )
+        >>> s
+        0                               POINT (0.5 2.5)
+        1    LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2       POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Point(0, 2),
+        ...         LineString([(0, 0), (0.5, 0.5), (1.0, 1.0)]),
+        ...         Point(8, 10),
+        ...     ],
+        ...     index=range(1, 4),
+        ... )
+        >>> s2
+        1                       POINT (0 2)
+        2    LINESTRING (0 0, 0.5 0.5, 1 1)
+        3                      POINT (8 10)
+        dtype: geometry
+
+        We can snap each geometry to a single shapely geometry:
+
+        >>> s.snap(Point(0, 2), tolerance=1)
+        0                                     POINT (0 2)
+        1      LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2    POLYGON ((0 0, 0 2, 0 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+
+        We can also snap two GeoSeries to each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and snap elements with the same index using
+        ``align=True`` or ignore index and snap elements based on their matching
+        order using ``align=False``:
+
+        >>> s.snap(s2, tolerance=1, align=True)
+        0                                                 None
+        1           LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2    POLYGON ((0.5 0.5, 1 1, 0 10, 10 10, 10 0, 0.5...
+        3                                                 None
+        dtype: geometry
+
+        >>> s.snap(s2, tolerance=1, align=False)
+        0                                      POINT (0 2)
+        1                   LINESTRING (0 0, 0.5 0.5, 1 1)
+        2    POLYGON ((0 0, 0 10, 8 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+        """
+        return _delegate_to_geometry_column("snap", self, other, tolerance, align)
+
+    @property
+    def bounds(self) -> ps.DataFrame:
+        """Returns a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
+        ``maxy`` values containing the bounds for each geometry.
+
+        See ``GeoSeries.total_bounds`` for the limits of the entire series.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, Polygon, LineString
+        >>> d = {'geometry': [Point(2, 1), Polygon([(0, 0), (1, 1), (1, 0)]),
+        ... LineString([(0, 1), (1, 2)])]}
+        >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
+        >>> gdf.bounds
+           minx  miny  maxx  maxy
+        0   2.0   1.0   2.0   1.0
+        1   0.0   0.0   1.0   1.0
+        2   0.0   1.0   1.0   2.0
+
+        You can assign the bounds to the ``GeoDataFrame`` as:
+
+        >>> import pandas as pd
+        >>> gdf = pd.concat([gdf, gdf.bounds], axis=1)
+        >>> gdf
+                                geometry  minx  miny  maxx  maxy
+        0                     POINT (2 1)   2.0   1.0   2.0   1.0
+        1  POLYGON ((0 0, 1 1, 1 0, 0 0))   0.0   0.0   1.0   1.0
+        2           LINESTRING (0 1, 1 2)   0.0   1.0   1.0   2.0
+        """
+        return _delegate_to_geometry_column("bounds", self)
+
+    @property
+    def total_bounds(self):
+        """Returns a tuple containing ``minx``, ``miny``, ``maxx``, ``maxy``
+        values for the bounds of the series as a whole.
+
+        See ``GeoSeries.bounds`` for the bounds of the geometries contained in
+        the series.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, Polygon, LineString
+        >>> d = {'geometry': [Point(3, -1), Polygon([(0, 0), (1, 1), (1, 0)]),
+        ... LineString([(0, 1), (1, 2)])]}
+        >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
+        >>> gdf.total_bounds
+        array([ 0., -1.,  3.,  2.])
+        """
+        return _delegate_to_geometry_column("total_bounds", self)
+
+    def dwithin(self, other, distance, align=None):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is within a set distance from ``other``.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test for
+            equality.
+        distance : float, np.array, pd.Series
+            Distance(s) to test if each geometry is within. A scalar distance will be
+            applied to all geometries. An array or Series will be applied elementwise.
+            If np.array or pd.Series are used then it must have same length as the
+            GeoSeries.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices.
+            If False, the order of elements is preserved. None defaults to True.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(0, 4),
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(1, 0), (4, 2), (2, 2)]),
+        ...         Polygon([(2, 0), (3, 2), (2, 2)]),
+        ...         LineString([(2, 0), (2, 2)]),
+        ...         Point(1, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1             LINESTRING (0 0, 0 2)
+        2             LINESTRING (0 0, 0 1)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((1 0, 4 2, 2 2, 1 0))
+        2    POLYGON ((2 0, 3 2, 2 2, 2 0))
+        3             LINESTRING (2 0, 2 2)
+        4                       POINT (1 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries contains a single
+        geometry:
+
+        >>> point = Point(0, 1)
+        >>> s2.dwithin(point, 1.8)
+        1     True
+        2    False
+        3    False
+        4     True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.dwithin(s2, distance=1, align=True)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.dwithin(s2, distance=1, align=False)
+        0     True
+        1    False
+        2    False
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is within the set distance of *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.within
+        """
+        return _delegate_to_geometry_column("dwithin", self, other, distance, align)
+
+    def difference(self, other, align=None):
+        """Returns a ``GeoSeries`` of the points in each aligned geometry that
+        are not in `other`.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Unlike Geopandas, Sedona does not support this operation for GeometryCollections.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            difference to.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        GeoSeries
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 6),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (1 0, 1 3)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (1 1)
+        5                       POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries contains a single
+        geometry:
+
+        >>> point = Point(0, 1)
+        >>> s2.difference(point)
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (1 0, 1 3)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (1 1)
+        5           GEOMETRYCOLLECTION EMPTY
+        dtype: geometry
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.difference(s2, align=True)
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (0 1)
+        5                       POINT (0 1)
+        dtype: geometry
+
+        >>> s.difference(s2, align=False)
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2           GEOMETRYCOLLECTION EMPTY
+        3             LINESTRING (2 0, 0 2)
+        4           GEOMETRYCOLLECTION EMPTY
+        dtype: geometry
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is different from *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.intersection
+        """
+        return _delegate_to_geometry_column("difference", self, other, align)
+
     def intersection_all(self):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def contains(self, other, align=None):
-        raise NotImplementedError("This method is not implemented yet.")
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that contains `other`.
 
-    @abstractmethod
+        An object is said to contain `other` if at least one point of `other` lies in
+        the interior and no points of `other` lie in the exterior of the object.
+        (Therefore, any given polygon does not contain its own boundary - there is not
+        any point that lies in the interior.)
+        If either object is empty, this operation returns ``False``.
+
+        This is the inverse of `within` in the sense that the expression
+        ``a.contains(b) == b.within(a)`` always evaluates to ``True``.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if it
+            is contained.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(0, 4),
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1             LINESTRING (0 0, 0 2)
+        2             LINESTRING (0 0, 0 1)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2    POLYGON ((0 0, 1 2, 0 2, 0 0))
+        3             LINESTRING (0 0, 0 2)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries contains a single
+        geometry:
+
+        >>> point = Point(0, 1)
+        >>> s.contains(point)
+        0    False
+        1     True
+        2    False
+        3     True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s2.contains(s, align=True)
+        0    False
+        1    False
+        2    False
+        3     True
+        4    False
+        dtype: bool
+
+        >>> s2.contains(s, align=False)
+        1     True
+        2    False
+        3     True
+        4     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``contains`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.contains_properly
+        GeoSeries.within
+        """
+        return _delegate_to_geometry_column("contains", self, other, align)
+
     def contains_properly(self, other, align=None):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def to_parquet(self, path, **kwargs):
         raise NotImplementedError("This method is not implemented yet.")
 
-    @abstractmethod
     def buffer(
         self,
         distance,
@@ -312,8 +2136,96 @@ class GeoFrame(metaclass=ABCMeta):
         single_sided=False,
         **kwargs,
     ):
-        raise NotImplementedError("This method is not implemented yet.")
+        return _delegate_to_geometry_column(
+            "buffer",
+            self,
+            distance,
+            resolution,
+            cap_style,
+            join_style,
+            mitre_limit,
+            single_sided,
+            **kwargs,
+        )
 
-    @abstractmethod
+    def simplify(self, tolerance=None, preserve_topology=True):
+        """Returns a ``GeoSeries`` containing a simplified representation of
+        each geometry.
+
+        The algorithm (Douglas-Peucker) recursively splits the original line
+        into smaller parts and connects these parts' endpoints
+        by a straight line. Then, it removes all points whose distance
+        to the straight line is smaller than `tolerance`. It does not
+        move any points and it always preserves endpoints of
+        the original line or polygon.
+        See https://shapely.readthedocs.io/en/latest/manual.html#object.simplify
+        for details
+
+        Simplifies individual geometries independently, without considering
+        the topology of a potential polygonal coverage. If you would like to treat
+        the ``GeoSeries`` as a coverage and simplify its edges, while preserving the
+        coverage topology, see :meth:`simplify_coverage`.
+
+        Parameters
+        ----------
+        tolerance : float
+            All parts of a simplified geometry will be no more than
+            `tolerance` distance from the original. It has the same units
+            as the coordinate reference system of the GeoSeries.
+            For example, using `tolerance=100` in a projected CRS with meters
+            as units means a distance of 100 meters in reality.
+        preserve_topology: bool (default True)
+            False uses a quicker algorithm, but may produce self-intersecting
+            or otherwise invalid geometries.
+
+        Notes
+        -----
+        Invalid geometric objects may result from simplification that does not
+        preserve topology and simplification may be sensitive to the order of
+        coordinates: two geometries differing only in order of coordinates may be
+        simplified differently.
+
+        See also
+        --------
+        simplify_coverage : simplify geometries using coverage simplification
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point, LineString
+        >>> s = GeoSeries(
+        ...     [Point(0, 0).buffer(1), LineString([(0, 0), (1, 10), (0, 20)])]
+        ... )
+        >>> s
+        0    POLYGON ((1 0, 0.99518 -0.09802, 0.98079 -0.19...
+        1                         LINESTRING (0 0, 1 10, 0 20)
+        dtype: geometry
+
+        >>> s.simplify(1)
+        0    POLYGON ((0 1, 0 -1, -1 0, 0 1))
+        1              LINESTRING (0 0, 0 20)
+        dtype: geometry
+        """
+        return _delegate_to_geometry_column(
+            "simplify", self, tolerance, preserve_topology
+        )
+
     def sjoin(self, other, predicate="intersects", **kwargs):
         raise NotImplementedError("This method is not implemented yet.")
+
+
+def _delegate_to_geometry_column(op, this, *args, **kwargs):
+    geom_column = this.geometry
+    if args or kwargs:
+        data = getattr(geom_column, op)(*args, **kwargs)
+    else:
+        data = getattr(geom_column, op)
+        # If it was a function instead of a property, call it
+        if callable(data):
+            data = data()
+
+    if kwargs.get("inplace", False):
+        this._update_inplace(geom_column)
+        return None
+
+    return data

--- a/python/sedona/geopandas/geodataframe.py
+++ b/python/sedona/geopandas/geodataframe.py
@@ -413,8 +413,9 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         from pyspark.sql import DataFrame as SparkDataFrame
 
         if isinstance(data, GeoDataFrame):
-            if data._safe_get_crs() is None:
-                data.crs = crs
+            data_crs = data._safe_get_crs()
+            if data_crs is not None:
+                data.crs = data_crs
 
             super().__init__(data, index=index, columns=columns, dtype=dtype, copy=copy)
 
@@ -537,7 +538,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     "df.set_geometry. "
                 )
 
-            raise AttributeError(msg)
+            raise MissingGeometryColumnError(msg)
         return self[self._geometry_column_name]
 
     def _set_geometry(self, col):
@@ -872,7 +873,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
         Parameters:
         - deep: bool, default False
-            If True, a deep copy of the data is made. Otherwise, a shallow copy is made.
+            This parameter is not supported but just a dummy parameter to match pandas.
 
         Returns:
         - GeoDataFrame: A copy of this GeoDataFrame object.
@@ -895,33 +896,6 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         else:
             return self  # GeoDataFrame(self._internal.spark_frame.copy())  "this parameter is not supported but just dummy parameter to match pandas."
 
-    @property
-    def area(self) -> GeoDataFrame:
-        """
-        Returns a GeoDataFrame containing the area of each geometry expressed in the units of the CRS.
-
-        Returns
-        -------
-        GeoDataFrame
-            A GeoDataFrame with the areas of the geometries.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon
-        >>> from sedona.geopandas import GeoDataFrame
-        >>>
-        >>> data = {
-        ...     'geometry': [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])],
-        ...     'value': [1, 2]
-        ... }
-        >>> gdf = GeoDataFrame(data)
-        >>> gdf.area
-           geometry_area  value
-        0           1.0      1
-        1           4.0      2
-        """
-        return self.geometry.area
-
     def _safe_get_crs(self):
         """
         Helper method for getting the crs of the GeoDataframe safely.
@@ -929,7 +903,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         """
         try:
             return self.geometry.crs
-        except AttributeError:
+        except MissingGeometryColumnError:
             return None
 
     @property
@@ -1233,302 +1207,15 @@ es": {"name": "urn:ogc:def:crs:EPSG::3857"}}}'
         raise NotImplementedError("to_feather() is not implemented yet.")
 
     @property
-    def geom_type(self) -> str:
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "geom_type",
-                "Returns the geometry type of each geometry (Point, LineString, Polygon, etc.).",
-            )
-        )
-
-    @property
     def type(self):
         # Implementation of the abstract method
         raise NotImplementedError(
             _not_implemented_error("type", "Returns numeric geometry type codes.")
         )
 
-    @property
-    def length(self):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "length", "Returns the length/perimeter of each geometry."
-            )
-        )
-
-    @property
-    def is_valid(self):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "is_valid", "Tests if geometries are valid according to OGC standards."
-            )
-        )
-
-    def is_valid_reason(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def is_empty(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def count_coordinates(self):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "count_coordinates",
-                "Counts the number of coordinate tuples in each geometry.",
-            )
-        )
-
-    def count_geometries(self):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "count_geometries",
-                "Counts the number of geometries in each multi-geometry or collection.",
-            )
-        )
-
-    def count_interior_rings(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def is_simple(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def is_ring(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def is_ccw(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def is_closed(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def has_z(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def get_precision(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def get_geometry(self, index):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def boundary(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def centroid(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def concave_hull(self, ratio=0.0, allow_holes=False):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def convex_hull(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def delaunay_triangles(self, tolerance=0.0, only_edges=False):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def voronoi_polygons(self, tolerance=0.0, extend_to=None, only_edges=False):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def envelope(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def minimum_rotated_rectangle(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def exterior(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def extract_unique_points(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def offset_curve(self, distance, quad_segs=8, join_style="round", mitre_limit=5.0):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def interiors(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def remove_repeated_points(self, tolerance=0.0):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def set_precision(self, grid_size, mode="valid_output"):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def representative_point(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def minimum_bounding_circle(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def minimum_bounding_radius(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def minimum_clearance(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def normalize(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def make_valid(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def reverse(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def segmentize(self, max_segment_length):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def transform(self, transformation, include_z=False):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def force_2d(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def force_3d(self, z=0):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def line_merge(self, directed=False):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    @property
-    def unary_union(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def union_all(self, method="unary", grid_size=None):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def intersection_all(self):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
-
-    def contains(self, other, align=None):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "contains", "Tests if geometries contain other geometries."
-            )
-        )
-
-    def contains_properly(self, other, align=None):
-        # Implementation of the abstract method
-        raise NotImplementedError(
-            _not_implemented_error(
-                "contains_properly",
-                "Tests if geometries properly contain other geometries (no boundary contact).",
-            )
-        )
-
     # ============================================================================
     # SPATIAL OPERATIONS
     # ============================================================================
-
-    def buffer(
-        self,
-        distance,
-        resolution=16,
-        cap_style="round",
-        join_style="round",
-        mitre_limit=5.0,
-        single_sided=False,
-        **kwargs,
-    ) -> sgpd.GeoSeries:
-        """
-        Returns a GeoSeries with all geometries buffered by the specified distance.
-
-        Parameters
-        ----------
-        distance : float
-            The distance to buffer by. Negative distances will create inward buffers.
-        resolution : int, default 16
-            The number of segments used to approximate curves.
-        cap_style : str, default "round"
-            The style of the buffer cap. One of 'round', 'flat', 'square'.
-        join_style : str, default "round"
-            The style of the buffer join. One of 'round', 'mitre', 'bevel'.
-        mitre_limit : float, default 5.0
-            The mitre limit ratio for joins when join_style='mitre'.
-        single_sided : bool, default False
-            Whether to create a single-sided buffer.
-
-        Returns
-        -------
-        GeoSeries
-            A new GeoSeries with buffered geometries.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Point
-        >>> from sedona.geopandas import GeoDataFrame
-        >>>
-        >>> data = {
-        ...     'geometry': [Point(0, 0), Point(1, 1)],
-        ...     'value': [1, 2]
-        ... }
-        >>> gdf = GeoDataFrame(data)
-        >>> buffered = gdf.buffer(0.5)
-        """
-        return self.geometry.buffer(
-            distance,
-            resolution=16,
-            cap_style="round",
-            join_style="round",
-            mitre_limit=5.0,
-            single_sided=False,
-            **kwargs,
-        )
 
     def sjoin(
         self,
@@ -1726,9 +1413,6 @@ def _ensure_geometry(data, crs: Any | None = None) -> sgpd.GeoSeries:
     """
     Ensure the data is of geometry dtype or converted to it.
 
-    If input is a (Geo)Series, output is a GeoSeries, otherwise output
-    is GeometryArray.
-
     If the input is a GeometryDtype with a set CRS, `crs` is ignored.
     """
     if isinstance(data, sgpd.GeoSeries):
@@ -1739,3 +1423,8 @@ def _ensure_geometry(data, crs: Any | None = None) -> sgpd.GeoSeries:
         return data
     else:
         return sgpd.GeoSeries(data, crs=crs)
+
+
+# We don't raise AttributeError because that would be caught by pyspark's __getattr__ creating a misleading error message
+class MissingGeometryColumnError(Exception):
+    pass

--- a/python/sedona/geopandas/geodataframe.py
+++ b/python/sedona/geopandas/geodataframe.py
@@ -39,6 +39,7 @@ from pandas.api.extensions import register_extension_dtype
 from geopandas.geodataframe import crs_mismatch_error
 from geopandas.array import GeometryDtype
 from shapely.geometry.base import BaseGeometry
+from pyspark.pandas.internal import SPARK_DEFAULT_INDEX_NAME, NATURAL_ORDER_COLUMN_NAME
 
 register_extension_dtype(GeometryDtype)
 
@@ -344,7 +345,7 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
             # Here we are getting a ps.Series with the same underlying anchor (ps.Dataframe).
             # This is important so we don't unnecessarily try to perform operations on different dataframes
-            ps_series = pspd.DataFrame.__getitem__(self, column_name)
+            ps_series: pspd.Series = pspd.DataFrame.__getitem__(self, column_name)
 
             try:
                 result = sgpd.GeoSeries(ps_series)
@@ -444,9 +445,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 assert index is None
                 assert dtype is None
                 assert not copy
-                df = data
+                # Need to convert GeoDataFrame to pd.DataFrame for below cast to work
+                pd_df = (
+                    pd.DataFrame(data) if isinstance(data, gpd.GeoDataFrame) else data
+                )
             else:
-                df = pd.DataFrame(
+                pd_df = pd.DataFrame(
                     data=data,
                     index=index,
                     dtype=dtype,
@@ -454,7 +458,8 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                 )
 
             # Spark complains if it's left as a geometry type
-            pd_df = df.astype(object)
+            geom_type_cols = pd_df.select_dtypes(include=["geometry"]).columns
+            pd_df[geom_type_cols] = pd_df[geom_type_cols].astype(object)
 
             # initialize the parent class pyspark Dataframe with the pandas Dataframe
             super().__init__(
@@ -630,13 +635,14 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     "`set_geometry` when this is the case."
                 )
                 warnings.warn(msg, category=FutureWarning, stacklevel=2)
-            if isinstance(col, (pspd.Series, pd.Series)) and col.name is not None:
-                geo_column_name = col.name
-
-            level = col
-
-            if not isinstance(level, pspd.Series):
-                level = pspd.Series(level)
+            if isinstance(col, (pspd.Series, pd.Series)):
+                if col.name is not None:
+                    geo_column_name = col.name
+                    level = col
+                else:
+                    level = col.rename(geo_column_name)
+            else:
+                level = pspd.Series(col, name=geo_column_name)
         elif hasattr(col, "ndim") and col.ndim > 1:
             raise ValueError("Must pass array with one dimension only.")
         else:  # should be a colname
@@ -746,17 +752,18 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
         if col in self.columns:
             raise ValueError(f"Column named {col} already exists")
         else:
+            mapper = {col: col for col in list(self.columns)}
+            mapper[geometry_col] = col
+
             if inplace:
-                self.rename(columns={geometry_col: col}, inplace=inplace)
-                self.set_geometry(col, inplace=inplace)
+                self.rename(columns=mapper, inplace=True, errors="raise")
+                self.set_geometry(col, inplace=True)
                 return None
 
-            # The same .rename().set_geometry() logic errors for this case, so we do it manually instead
-            ps_series = self._psser_for((geometry_col,)).rename(col)
-            sdf = self.copy()
-            sdf[col] = ps_series
-            sdf = sdf.set_geometry(col)
-            return sdf
+            df = self.copy()
+            df.rename(columns=mapper, inplace=True, errors="raise")
+            df.set_geometry(col, inplace=True)
+            return df
 
     # ============================================================================
     # PROPERTIES AND ATTRIBUTES

--- a/python/sedona/geopandas/geodataframe.py
+++ b/python/sedona/geopandas/geodataframe.py
@@ -43,9 +43,265 @@ from shapely.geometry.base import BaseGeometry
 register_extension_dtype(GeometryDtype)
 
 
+# ============================================================================
+# IMPLEMENTATION STATUS TRACKING
+# ============================================================================
+
+IMPLEMENTATION_STATUS = {
+    "IMPLEMENTED": [
+        "area",
+        "buffer",
+        "crs",
+        "geometry",
+        "active_geometry_name",
+        "sindex",
+        "rename_geometry",
+        "copy",
+        "sjoin",
+        "to_parquet",
+    ],
+    "NOT_IMPLEMENTED": [
+        "to_geopandas",
+        "_to_geopandas",
+        "geom_type",
+        "type",
+        "length",
+        "is_valid",
+        "is_valid_reason",
+        "is_empty",
+        "is_simple",
+        "is_ring",
+        "is_ccw",
+        "is_closed",
+        "has_z",
+        "boundary",
+        "centroid",
+        "convex_hull",
+        "envelope",
+        "exterior",
+        "interiors",
+        "unary_union",
+        "count_coordinates",
+        "count_geometries",
+        "count_interior_rings",
+        "get_precision",
+        "get_geometry",
+        "concave_hull",
+        "delaunay_triangles",
+        "voronoi_polygons",
+        "minimum_rotated_rectangle",
+        "extract_unique_points",
+        "offset_curve",
+        "remove_repeated_points",
+        "set_precision",
+        "representative_point",
+        "minimum_bounding_circle",
+        "minimum_bounding_radius",
+        "minimum_clearance",
+        "normalize",
+        "make_valid",
+        "reverse",
+        "segmentize",
+        "transform",
+        "force_2d",
+        "force_3d",
+        "line_merge",
+        "union_all",
+        "intersection_all",
+        "contains",
+        "contains_properly",
+    ],
+    "PARTIALLY_IMPLEMENTED": ["set_geometry"],  # Only drop=True case is not implemented
+}
+
+IMPLEMENTATION_PRIORITY = {
+    "HIGH": [
+        "to_geopandas",
+        "_to_geopandas",
+        "contains",
+        "contains_properly",
+        "convex_hull",
+        "count_coordinates",
+        "count_geometries",
+        "is_ring",
+        "is_closed",
+        "make_valid",
+    ],
+    "MEDIUM": [
+        "force_2d",
+        "force_3d",
+        "transform",
+        "segmentize",
+        "line_merge",
+        "union_all",
+        "intersection_all",
+        "reverse",
+        "normalize",
+        "get_geometry",
+    ],
+    "LOW": [
+        "delaunay_triangles",
+        "voronoi_polygons",
+        "minimum_bounding_circle",
+        "representative_point",
+        "extract_unique_points",
+        "offset_curve",
+        "minimum_rotated_rectangle",
+        "concave_hull",
+    ],
+}
+
+
+def _not_implemented_error(method_name: str, additional_info: str = "") -> str:
+    """
+    Generate a standardized NotImplementedError message for GeoDataFrame methods.
+
+    Parameters
+    ----------
+    method_name : str
+        The name of the method that is not implemented.
+    additional_info : str, optional
+        Additional information about the method or workarounds.
+
+    Returns
+    -------
+    str
+        Formatted error message.
+    """
+    base_message = (
+        f"GeoDataFrame.{method_name}() is not implemented yet.\n"
+        f"This method will be added in a future release."
+    )
+
+    if additional_info:
+        base_message += f"\n\n{additional_info}"
+
+    workaround = (
+        "\n\nTemporary workaround - use GeoPandas:\n"
+        "  gpd_df = sedona_gdf.to_geopandas()\n"
+        f"  result = gpd_df.{method_name}(...)\n"
+        "  # Note: This will collect all data to the driver."
+    )
+
+    return base_message + workaround
+
+
 class GeoDataFrame(GeoFrame, pspd.DataFrame):
     """
-    A class representing a GeoDataFrame, inheriting from GeoFrame and pyspark.pandas.DataFrame.
+    A pandas-on-Spark DataFrame for geospatial data with geometry columns.
+
+    GeoDataFrame extends pyspark.pandas.DataFrame to provide geospatial operations
+    using Apache Sedona's spatial functions. It maintains compatibility with
+    GeoPandas GeoDataFrame while operating on distributed datasets.
+
+    Parameters
+    ----------
+    data : dict, array-like, DataFrame, or GeoDataFrame
+        Data to initialize the GeoDataFrame. Can be a dictionary, array-like structure,
+        pandas DataFrame, GeoPandas GeoDataFrame, or another GeoDataFrame.
+    geometry : str, array-like, or GeoSeries, optional
+        Column name, array of geometries, or GeoSeries to use as the active geometry.
+        If None, will look for existing geometry columns.
+    crs : pyproj.CRS, optional
+        Coordinate Reference System for the geometries.
+    columns : Index or array-like, optional
+        Column labels to use for the resulting frame.
+    index : Index or array-like, optional
+        Index to use for the resulting frame.
+
+    Attributes
+    ----------
+    geometry : GeoSeries
+        The active geometry column.
+    crs : pyproj.CRS
+        The Coordinate Reference System (CRS) for the geometries.
+    active_geometry_name : str
+        Name of the active geometry column.
+    area : Series
+        Area of each geometry in CRS units.
+    sindex : SpatialIndex
+        Spatial index for the geometries.
+
+    Methods
+    -------
+    buffer(distance)
+        Buffer geometries by specified distance.
+    sjoin(right, how='inner', predicate='intersects')
+        Spatial join with another GeoDataFrame.
+    set_geometry(col, drop=False, inplace=False)
+        Set the active geometry column.
+    rename_geometry(col, inplace=False)
+        Rename the active geometry column.
+    to_parquet(path, **kwargs)
+        Save to GeoParquet format.
+    copy(deep=False)
+        Make a copy of the GeoDataFrame.
+
+    Examples
+    --------
+    >>> from shapely.geometry import Point, Polygon
+    >>> from sedona.geopandas import GeoDataFrame
+    >>> import pandas as pd
+    >>>
+    >>> # Create from dictionary with geometry
+    >>> data = {
+    ...     'name': ['A', 'B', 'C'],
+    ...     'geometry': [Point(0, 0), Point(1, 1), Point(2, 2)]
+    ... }
+    >>> gdf = GeoDataFrame(data, crs='EPSG:4326')
+    >>> gdf
+         name   geometry
+    0       A   POINT (0 0)
+    1       B   POINT (1 1)
+    2       C   POINT (2 2)
+    >>>
+    >>> # Spatial operations
+    >>> buffered = gdf.buffer(0.1)
+    >>> buffered.area
+    0    0.031416
+    1    0.031416
+    2    0.031416
+    dtype: float64
+    >>>
+    >>> # Spatial joins
+    >>> polygons = GeoDataFrame({
+    ...     'region': ['Region1', 'Region2'],
+    ...     'geometry': [
+    ...         Polygon([(-1, -1), (1, -1), (1, 1), (-1, 1)]),
+    ...         Polygon([(0.5, 0.5), (2.5, 0.5), (2.5, 2.5), (0.5, 2.5)])
+    ...     ]
+    ... })
+    >>> result = gdf.sjoin(polygons, how='left', predicate='within')
+    >>> result['region']
+    0    Region1
+    1    Region2
+    2    Region2
+    dtype: object
+
+    Notes
+    -----
+    This implementation differs from GeoPandas in several ways:
+    - Uses Spark for distributed processing
+    - Geometries are stored in WKB (Well-Known Binary) format internally
+    - Some methods may have different performance characteristics
+    - Not all GeoPandas methods are implemented yet (see IMPLEMENTATION_STATUS)
+
+    Performance Considerations:
+    - Operations are distributed across Spark cluster
+    - Avoid converting to GeoPandas (.to_geopandas()) on large datasets
+    - Use .sample() for testing with large datasets
+    - Spatial joins are optimized for distributed processing
+
+    Geometry Column Management:
+    - Supports multiple geometry columns
+    - One geometry column is designated as 'active' at a time
+    - Active geometry is used for spatial operations and plotting
+    - Use set_geometry() to change the active geometry column
+
+    See Also
+    --------
+    geopandas.GeoDataFrame : The GeoPandas equivalent
+    sedona.geopandas.GeoSeries : Series with geometry data
     """
 
     def __getitem__(self, key: Any) -> Any:
@@ -119,6 +375,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             return GeoDataFrame(selected_rows)
 
     _geometry_column_name = None
+
+    # ============================================================================
+    # CONSTRUCTION AND INITIALIZATION
+    # ============================================================================
 
     def __init__(
         self,
@@ -235,6 +495,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             self._geometry_column_name = data._geometry_column_name
             if crs is not None and data.crs != crs:
                 raise ValueError(crs_mismatch_error)
+
+    # ============================================================================
+    # GEOMETRY COLUMN MANAGEMENT
+    # ============================================================================
 
     def _get_geometry(self) -> sgpd.GeoSeries:
         if self._geometry_column_name not in self:
@@ -432,7 +696,12 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
                     stacklevel=2,
                 )
             if drop:
-                raise NotImplementedError("Not implemented.")
+                raise NotImplementedError(
+                    _not_implemented_error(
+                        "set_geometry",
+                        "Setting geometry with drop=True parameter is not supported.",
+                    )
+                )
             else:
                 # if not dropping, set the active geometry name to the given col name
                 geo_column_name = col
@@ -516,6 +785,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             sdf = sdf.set_geometry(col)
             return sdf
 
+    # ============================================================================
+    # PROPERTIES AND ATTRIBUTES
+    # ============================================================================
+
     @property
     def active_geometry_name(self) -> Any:
         """Return the name of the active geometry column
@@ -591,11 +864,21 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
     def to_geopandas(self) -> gpd.GeoDataFrame | pd.Series:
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "to_geopandas",
+                "Converts to GeoPandas GeoDataFrame by collecting all data to driver.",
+            )
+        )
 
     def _to_geopandas(self) -> gpd.GeoDataFrame | pd.Series:
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "_to_geopandas",
+                "Internal method for GeoPandas conversion without logging warnings.",
+            )
+        )
 
     @property
     def sindex(self) -> SpatialIndex | None:
@@ -692,22 +975,37 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
     @property
     def geom_type(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "geom_type",
+                "Returns the geometry type of each geometry (Point, LineString, Polygon, etc.).",
+            )
+        )
 
     @property
     def type(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error("type", "Returns numeric geometry type codes.")
+        )
 
     @property
     def length(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "length", "Returns the length/perimeter of each geometry."
+            )
+        )
 
     @property
     def is_valid(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "is_valid", "Tests if geometries are valid according to OGC standards."
+            )
+        )
 
     def is_valid_reason(self):
         # Implementation of the abstract method
@@ -720,11 +1018,21 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
     def count_coordinates(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "count_coordinates",
+                "Counts the number of coordinate tuples in each geometry.",
+            )
+        )
 
     def count_geometries(self):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "count_geometries",
+                "Counts the number of geometries in each multi-geometry or collection.",
+            )
+        )
 
     def count_interior_rings(self):
         # Implementation of the abstract method
@@ -888,11 +1196,24 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
 
     def contains(self, other, align=None):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "contains", "Tests if geometries contain other geometries."
+            )
+        )
 
     def contains_properly(self, other, align=None):
         # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+        raise NotImplementedError(
+            _not_implemented_error(
+                "contains_properly",
+                "Tests if geometries properly contain other geometries (no boundary contact).",
+            )
+        )
+
+    # ============================================================================
+    # SPATIAL OPERATIONS
+    # ============================================================================
 
     def buffer(
         self,
@@ -1012,6 +1333,10 @@ class GeoDataFrame(GeoFrame, pspd.DataFrame):
             on_attribute=on_attribute,
             **kwargs,
         )
+
+    # ============================================================================
+    # I/O OPERATIONS
+    # ============================================================================
 
     def to_parquet(self, path, **kwargs):
         """

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -637,7 +637,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         new_epsg = crs.to_epsg() if crs else 0
 
         spark_col = stf.ST_SetSRID(self.spark.column, new_epsg)
-        result = self._query_geometry_column(spark_col)
+        result = self._query_geometry_column(spark_col, keep_name=True)
 
         if inplace:
             self._update_inplace(result)
@@ -655,6 +655,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         df: pyspark.sql.DataFrame = None,
         returns_geom: bool = True,
         is_aggr: bool = False,
+        keep_name: bool = False,
     ) -> Union["GeoSeries", pspd.Series]:
         """
         Helper method to query a single geometry column with a specified operation.
@@ -678,7 +679,10 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         df = self._internal.spark_frame if df is None else df
 
-        rename = self.name if self.name else SPARK_DEFAULT_SERIES_NAME
+        rename = SPARK_DEFAULT_SERIES_NAME
+
+        if keep_name and self.name:
+            rename = self.name
 
         col_expr = spark_col.alias(rename)
 
@@ -815,26 +819,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def area(self) -> pspd.Series:
-        """
-        Returns a Series containing the area of each geometry in the GeoSeries expressed in the units of the CRS.
-
-        Returns
-        -------
-        Series
-            A Series containing the area of each geometry.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon
-        >>> from sedona.geopandas import GeoSeries
-
-        >>> gs = GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])])
-        >>> gs.area
-        0    1.0
-        1    4.0
-        dtype: float64
-        """
-
         spark_col = stf.ST_Area(self.spark.column)
 
         return self._query_geometry_column(
@@ -844,27 +828,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def geom_type(self) -> pspd.Series:
-        """
-        Returns a series of strings specifying the geometry type of each geometry of each object.
-
-        Note: Unlike Geopandas, Sedona returns LineString instead of LinearRing.
-
-        Returns
-        -------
-        Series
-            A Series containing the geometry type of each geometry.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon, Point
-        >>> from sedona.geopandas import GeoSeries
-
-        >>> gs = GeoSeries([Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Point(0, 0)])
-        >>> gs.geom_type
-        0    POLYGON
-        1    POINT
-        dtype: object
-        """
         spark_col = stf.GeometryType(self.spark.column)
         result = self._query_geometry_column(
             spark_col,
@@ -893,32 +856,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def length(self) -> pspd.Series:
-        """
-        Returns a Series containing the length of each geometry in the GeoSeries.
-
-        In the case of a (Multi)Polygon it measures the length of its exterior (i.e. perimeter).
-
-        For a GeometryCollection it measures sums the values for each of the individual geometries.
-
-        Returns
-        -------
-        Series
-            A Series containing the length of each geometry.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon
-        >>> from sedona.geopandas import GeoSeries
-
-        >>> gs = GeoSeries([Point(0, 0), LineString([(0, 0), (1, 1)]), Polygon([(0, 0), (1, 0), (1, 1)]), GeometryCollection([Point(0, 0), LineString([(0, 0), (1, 1)]), Polygon([(0, 0), (1, 0), (1, 1)])])])
-        >>> gs.length
-        0    0.000000
-        1    1.414214
-        2    3.414214
-        3    4.828427
-        dtype: float64
-        """
-
         spark_expr = (
             F.when(
                 stf.GeometryType(self.spark.column).isin(
@@ -946,92 +883,14 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def is_valid(self) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        geometries that are valid.
-
-        Examples
-        --------
-
-        An example with one invalid polygon (a bowtie geometry crossing itself)
-        and one missing geometry:
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         Polygon([(0,0), (1, 1), (1, 0), (0, 1)]),  # bowtie geometry
-        ...         Polygon([(0, 0), (2, 2), (2, 0)]),
-        ...         None
-        ...     ]
-        ... )
-        >>> s
-        0         POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1    POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))
-        2         POLYGON ((0 0, 2 2, 2 0, 0 0))
-        3                                   None
-        dtype: geometry
-
-        >>> s.is_valid
-        0     True
-        1    False
-        2     True
-        3    False
-        dtype: bool
-
-        See also
-        --------
-        GeoSeries.is_valid_reason : reason for invalidity
-        """
-
         spark_col = stf.ST_IsValid(self.spark.column)
         result = self._query_geometry_column(
             spark_col,
             returns_geom=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def is_valid_reason(self) -> pspd.Series:
-        """Returns a ``Series`` of strings with the reason for invalidity of
-        each geometry.
-
-        Examples
-        --------
-
-        An example with one invalid polygon (a bowtie geometry crossing itself)
-        and one missing geometry:
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         Polygon([(0,0), (1, 1), (1, 0), (0, 1)]),  # bowtie geometry
-        ...         Polygon([(0, 0), (2, 2), (2, 0)]),
-        ...         Polygon([(0, 0), (2, 0), (1, 1), (2, 2), (0, 2), (1, 1), (0, 0)]),
-        ...         None
-        ...     ]
-        ... )
-        >>> s
-        0         POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1    POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))
-        2         POLYGON ((0 0, 2 2, 2 0, 0 0))
-        3                                   None
-        dtype: geometry
-
-        >>> s.is_valid_reason()
-        0    Valid Geometry
-        1    Self-intersection at or near point (0.5, 0.5, NaN)
-        2    Valid Geometry
-        3    Ring Self-intersection at or near point (1.0, 1.0)
-        4    None
-        dtype: object
-
-        See also
-        --------
-        GeoSeries.is_valid : detect invalid geometries
-        GeoSeries.make_valid : fix invalid geometries
-        """
         spark_col = stf.ST_IsValidReason(self.spark.column)
         return self._query_geometry_column(
             spark_col,
@@ -1040,39 +899,12 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def is_empty(self) -> pspd.Series:
-        """
-        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        empty geometries.
-
-        Examples
-        --------
-        An example of a GeoDataFrame with one empty point, one point and one missing
-        value:
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Point
-        >>> geoseries = GeoSeries([Point(), Point(2, 1), None], crs="EPSG:4326")
-        >>> geoseries
-        0  POINT EMPTY
-        1  POINT (2 1)
-        2         None
-
-        >>> geoseries.is_empty
-        0     True
-        1    False
-        2    False
-        dtype: bool
-
-        See Also
-        --------
-        GeoSeries.isna : detect missing values
-        """
         spark_expr = stf.ST_IsEmpty(self.spark.column)
         result = self._query_geometry_column(
             spark_expr,
             returns_geom=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def count_coordinates(self):
         # Implementation of the abstract method
@@ -1102,108 +934,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
 
     def dwithin(self, other, distance, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that is within a set distance from ``other``.
-
-        The operation works on a 1-to-1 row-wise manner:
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test for
-            equality.
-        distance : float, np.array, pd.Series
-            Distance(s) to test if each geometry is within. A scalar distance will be
-            applied to all geometries. An array or Series will be applied elementwise.
-            If np.array or pd.Series are used then it must have same length as the
-            GeoSeries.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices.
-            If False, the order of elements is preserved. None defaults to True.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (0, 2)]),
-        ...         LineString([(0, 0), (0, 1)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(0, 4),
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(1, 0), (4, 2), (2, 2)]),
-        ...         Polygon([(2, 0), (3, 2), (2, 2)]),
-        ...         LineString([(2, 0), (2, 2)]),
-        ...         Point(1, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1             LINESTRING (0 0, 0 2)
-        2             LINESTRING (0 0, 0 1)
-        3                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((1 0, 4 2, 2 2, 1 0))
-        2    POLYGON ((2 0, 3 2, 2 2, 2 0))
-        3             LINESTRING (2 0, 2 2)
-        4                       POINT (1 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries contains a single
-        geometry:
-
-        >>> point = Point(0, 1)
-        >>> s2.dwithin(point, 1.8)
-        1     True
-        2    False
-        3    False
-        4     True
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.dwithin(s2, distance=1, align=True)
-        0    False
-        1     True
-        2    False
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.dwithin(s2, distance=1, align=False)
-        0     True
-        1    False
-        2    False
-        3     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries is within the set distance of *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.within
-        """
-
         if not isinstance(distance, (float, int)):
             raise NotImplementedError(
                 "Array-like distance for dwithin not implemented yet."
@@ -1222,107 +952,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
 
     def difference(self, other, align=None) -> "GeoSeries":
-        """Returns a ``GeoSeries`` of the points in each aligned geometry that
-        are not in `other`.
-
-        The operation works on a 1-to-1 row-wise manner:
-
-        Unlike Geopandas, Sedona does not support this operation for GeometryCollections.
-
-        Parameters
-        ----------
-        other : Geoseries or geometric object
-            The Geoseries (elementwise) or geometric object to find the
-            difference to.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        GeoSeries
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(1, 0), (1, 3)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(1, 1),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 6),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        2             LINESTRING (0 0, 2 2)
-        3             LINESTRING (2 0, 0 2)
-        4                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        2             LINESTRING (1 0, 1 3)
-        3             LINESTRING (2 0, 0 2)
-        4                       POINT (1 1)
-        5                       POINT (0 1)
-        dtype: geometry
-
-        We can do difference of each geometry and a single
-        shapely geometry:
-
-        >>> s.difference(Polygon([(0, 0), (1, 1), (0, 1)]))
-        0       POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
-        1         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
-        2                       LINESTRING (1 1, 2 2)
-        3    MULTILINESTRING ((2 0, 1 1), (1 1, 0 2))
-        4                                 POINT EMPTY
-        dtype: geometry
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.difference(s2, align=True)
-        0                                        None
-        1         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
-        2    MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))
-        3                            LINESTRING EMPTY
-        4                                 POINT (0 1)
-        5                                        None
-        dtype: geometry
-
-        >>> s.difference(s2, align=False)
-        0         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
-        1    POLYGON ((0 0, 0 2, 1 2, 2 2, 1 1, 0 0))
-        2    MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))
-        3                       LINESTRING (2 0, 0 2)
-        4                                 POINT EMPTY
-        dtype: geometry
-
-        See Also
-        --------
-        GeoSeries.symmetric_difference
-        GeoSeries.union
-        GeoSeries.intersection
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -1336,37 +965,12 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def is_simple(self) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        geometries that do not cross themselves.
-
-        This is meaningful only for `LineStrings` and `LinearRings`.
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import LineString
-        >>> s = GeoSeries(
-        ...     [
-        ...         LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
-        ...         LineString([(0, 0), (1, 1), (1, -1)]),
-        ...     ]
-        ... )
-        >>> s
-        0    LINESTRING (0 0, 1 1, 1 -1, 0 1)
-        1         LINESTRING (0 0, 1 1, 1 -1)
-        dtype: geometry
-
-        >>> s.is_simple
-        0    False
-        1     True
-        dtype: bool
-        """
         spark_expr = stf.ST_IsSimple(self.spark.column)
         result = self._query_geometry_column(
             spark_expr,
             returns_geom=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     @property
     def is_ring(self):
@@ -1399,34 +1003,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def has_z(self) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        features that have a z-component.
-
-        Notes
-        -----
-        Every operation in GeoPandas is planar, i.e. the potential third
-        dimension is not taken into account.
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Point(0, 1),
-        ...         Point(0, 1, 2),
-        ...     ]
-        ... )
-        >>> s
-        0        POINT (0 1)
-        1    POINT Z (0 1 2)
-        dtype: geometry
-
-        >>> s.has_z
-        0    False
-        1     True
-        dtype: bool
-        """
         spark_expr = stf.ST_HasZ(self.spark.column)
         return self._query_geometry_column(
             spark_expr,
@@ -1438,79 +1014,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         raise NotImplementedError("This method is not implemented yet.")
 
     def get_geometry(self, index) -> "GeoSeries":
-        """Returns the n-th geometry from a collection of geometries (0-indexed).
-
-        If the index is non-negative, it returns the geometry at that index.
-        If the index is negative, it counts backward from the end of the collection (e.g., -1 returns the last geometry).
-        Returns None if the index is out of bounds.
-
-        Note: Simple geometries act as length-1 collections
-
-        Note: Using Shapely < 2.0, may lead to different results for empty simple geometries due to how
-        shapely interprets them.
-
-        Parameters
-        ----------
-        index : int or array_like
-            Position of a geometry to be retrieved within its collection
-
-        Returns
-        -------
-        GeoSeries
-
-        Notes
-        -----
-        Simple geometries act as collections of length 1. Any out-of-range index value
-        returns None.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Point, MultiPoint, GeometryCollection
-        >>> s = geopandas.GeoSeries(
-        ...     [
-        ...         Point(0, 0),
-        ...         MultiPoint([(0, 0), (1, 1), (0, 1), (1, 0)]),
-        ...         GeometryCollection(
-        ...             [MultiPoint([(0, 0), (1, 1), (0, 1), (1, 0)]), Point(0, 1)]
-        ...         ),
-        ...         Polygon(),
-        ...         GeometryCollection(),
-        ...     ]
-        ... )
-        >>> s
-        0                                          POINT (0 0)
-        1              MULTIPOINT ((0 0), (1 1), (0 1), (1 0))
-        2    GEOMETRYCOLLECTION (MULTIPOINT ((0 0), (1 1), ...
-        3                                        POLYGON EMPTY
-        4                             GEOMETRYCOLLECTION EMPTY
-        dtype: geometry
-
-        >>> s.get_geometry(0)
-        0                                POINT (0 0)
-        1                                POINT (0 0)
-        2    MULTIPOINT ((0 0), (1 1), (0 1), (1 0))
-        3                              POLYGON EMPTY
-        4                                       None
-        dtype: geometry
-
-        >>> s.get_geometry(1)
-        0           None
-        1    POINT (1 1)
-        2    POINT (0 1)
-        3           None
-        4           None
-        dtype: geometry
-
-        >>> s.get_geometry(-1)
-        0    POINT (0 0)
-        1    POINT (1 0)
-        2    POINT (0 1)
-        3  POLYGON EMPTY
-        4           None
-        dtype: geometry
-
-        """
-
         # Sedona errors on negative indexes, so we use a case statement to handle it ourselves
         spark_expr = stf.ST_GeometryN(
             F.col("L"),
@@ -1537,38 +1040,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def boundary(self) -> "GeoSeries":
-        """Returns a ``GeoSeries`` of lower dimensional objects representing
-        each geometry's set-theoretic `boundary`.
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (1, 1), (1, 0)]),
-        ...         Point(0, 0),
-        ...     ]
-        ... )
-        >>> s
-        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1        LINESTRING (0 0, 1 1, 1 0)
-        2                       POINT (0 0)
-        dtype: geometry
-
-        >>> s.boundary
-        0    LINESTRING (0 0, 1 1, 0 1, 0 0)
-        1          MULTIPOINT ((0 0), (1 0))
-        2           GEOMETRYCOLLECTION EMPTY
-        dtype: geometry
-
-        See also
-        --------
-        GeoSeries.exterior : outer boundary (without interior rings)
-
-        """
         # Geopandas and shapely return NULL for GeometryCollections, so we handle it separately
         # https://shapely.readthedocs.io/en/stable/reference/shapely.boundary.html
         spark_expr = F.when(
@@ -1581,39 +1052,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def centroid(self) -> "GeoSeries":
-        """Returns a ``GeoSeries`` of points representing the centroid of each
-        geometry.
-
-        Note that centroid does not have to be on or within original geometry.
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (1, 1), (1, 0)]),
-        ...         Point(0, 0),
-        ...     ]
-        ... )
-        >>> s
-        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1        LINESTRING (0 0, 1 1, 1 0)
-        2                       POINT (0 0)
-        dtype: geometry
-
-        >>> s.centroid
-        0    POINT (0.33333 0.66667)
-        1        POINT (0.70711 0.5)
-        2                POINT (0 0)
-        dtype: geometry
-
-        See also
-        --------
-        GeoSeries.representative_point : point guaranteed to be within each geometry
-        """
         spark_expr = stf.ST_Centroid(self.spark.column)
         return self._query_geometry_column(
             spark_expr,
@@ -1643,44 +1081,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def envelope(self) -> "GeoSeries":
-        """Returns a ``GeoSeries`` of geometries representing the envelope of
-        each geometry.
-
-        The envelope of a geometry is the bounding rectangle. That is, the
-        point or smallest rectangular polygon (with sides parallel to the
-        coordinate axes) that contains the geometry.
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (1, 1), (1, 0)]),
-        ...         MultiPoint([(0, 0), (1, 1)]),
-        ...         Point(0, 0),
-        ...     ]
-        ... )
-        >>> s
-        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1        LINESTRING (0 0, 1 1, 1 0)
-        2         MULTIPOINT ((0 0), (1 1))
-        3                       POINT (0 0)
-        dtype: geometry
-
-        >>> s.envelope
-        0    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-        1    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-        2    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-        3                            POINT (0 0)
-        dtype: geometry
-
-        See also
-        --------
-        GeoSeries.convex_hull : convex hull geometry
-        """
         spark_expr = stf.ST_Envelope(self.spark.column)
         return self._query_geometry_column(
             spark_expr,
@@ -1738,65 +1138,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         raise NotImplementedError("This method is not implemented yet.")
 
     def make_valid(self, *, method="linework", keep_collapsed=True) -> "GeoSeries":
-        """Repairs invalid geometries.
-
-        Returns a ``GeoSeries`` with valid geometries.
-
-        If the input geometry is already valid, then it will be preserved.
-        In many cases, in order to create a valid geometry, the input
-        geometry must be split into multiple parts or multiple geometries.
-        If the geometry must be split into multiple parts of the same type
-        to be made valid, then a multi-part geometry will be returned
-        (e.g. a MultiPolygon).
-        If the geometry must be split into multiple parts of different types
-        to be made valid, then a GeometryCollection will be returned.
-
-        In Sedona, only the 'structure' method is available:
-
-        * the 'structure' algorithm tries to reason from the structure of the
-          input to find the 'correct' repair: exterior rings bound area,
-          interior holes exclude area. It first makes all rings valid, then
-          shells are merged and holes are subtracted from the shells to
-          generate valid result. It assumes that holes and shells are correctly
-          categorized in the input geometry.
-
-        Parameters
-        ----------
-        method : {'linework', 'structure'}, default 'linework'
-            Algorithm to use when repairing geometry. Sedona Geopandas only supports the 'structure' method.
-            The default method is "linework" to match compatibility with Geopandas, but it must be explicitly set to
-            'structure' to use the Sedona implementation.
-
-        keep_collapsed : bool, default True
-            For the 'structure' method, True will keep components that have
-            collapsed into a lower dimensionality. For example, a ring
-            collapsing to a line, or a line collapsing to a point.
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import MultiPolygon, Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)]),
-        ...         Polygon([(0, 2), (0, 1), (2, 0), (0, 0), (0, 2)]),
-        ...         LineString([(0, 0), (1, 1), (1, 0)]),
-        ...     ],
-        ... )
-        >>> s
-        0    POLYGON ((0 0, 0 2, 1 1, 2 2, 2 0, 1 1, 0 0))
-        1              POLYGON ((0 2, 0 1, 2 0, 0 0, 0 2))
-        2                       LINESTRING (0 0, 1 1, 1 0)
-        dtype: geometry
-
-        >>> s.make_valid()
-        0    MULTIPOLYGON (((1 1, 0 0, 0 2, 1 1)), ((2 0, 1...
-        1                       POLYGON ((0 1, 2 0, 0 0, 0 1))
-        2                           LINESTRING (0 0, 1 1, 1 0)
-        dtype: geometry
-        """
-
         if method != "structure":
             raise ValueError(
                 "Sedona only supports the 'structure' method for make_valid"
@@ -1842,34 +1183,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         raise NotImplementedError("This method is not implemented yet.")
 
     def union_all(self, method="unary", grid_size=None) -> BaseGeometry:
-        """Returns a geometry containing the union of all geometries in the
-        ``GeoSeries``.
-
-        Sedona does not support the method or grid_size argument, so the user does not need to manually
-        decide the algorithm being used.
-
-        Parameters
-        ----------
-        method : str (default ``"unary"``)
-            Not supported in Sedona.
-
-        grid_size : float, default None
-            Not supported in Sedona.
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import box
-        >>> s = GeoSeries([box(0, 0, 1, 1), box(0, 0, 2, 2)])
-        >>> s
-        0    POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))
-        1    POLYGON ((2 0, 2 2, 0 2, 0 0, 2 0))
-        dtype: geometry
-
-        >>> s.union_all()
-        <POLYGON ((0 1, 0 2, 2 2, 2 0, 1 0, 0 0, 0 1))>
-        """
         if grid_size is not None:
             raise NotImplementedError("Sedona does not support the grid_size argument")
         if method != "unary":
@@ -1894,111 +1207,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         return geom
 
     def crosses(self, other, align=None) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that cross `other`.
-
-        An object is said to cross `other` if its `interior` intersects the
-        `interior` of the other but does not contain it, and the dimension of
-        the intersection is less than the dimension of the one or the other.
-
-        Note: Unlike Geopandas, Sedona's implementation always return NULL when GeometryCollection is involved.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if is
-            crossed.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         LineString([(1, 0), (1, 3)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(1, 1),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1             LINESTRING (0 0, 2 2)
-        2             LINESTRING (2 0, 0 2)
-        3                       POINT (0 1)
-        dtype: geometry
-        >>> s2
-        1    LINESTRING (1 0, 1 3)
-        2    LINESTRING (2 0, 0 2)
-        3              POINT (1 1)
-        4              POINT (0 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries crosses a single
-        geometry:
-
-        >>> line = LineString([(-1, 1), (3, 1)])
-        >>> s.crosses(line)
-        0     True
-        1     True
-        2     True
-        3    False
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.crosses(s2, align=True)
-        0    False
-        1     True
-        2    False
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.crosses(s2, align=False)
-        0     True
-        1     True
-        2    False
-        3    False
-        dtype: bool
-
-        Notice that a line does not cross a point that it contains.
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``crosses`` *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.disjoint
-        GeoSeries.intersects
-
-        """
         # Sedona does not support GeometryCollection (errors), so we return NULL for now to avoid error
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
@@ -2015,7 +1223,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             default_val=False,
         )
 
-        return to_bool(result)
+        return _to_bool(result)
 
     def disjoint(self, other, align=None):
         # Implementation of the abstract method
@@ -2024,108 +1232,6 @@ class GeoSeries(GeoFrame, pspd.Series):
     def intersects(
         self, other: Union["GeoSeries", BaseGeometry], align: Union[bool, None] = None
     ) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that intersects `other`.
-
-        An object is said to intersect `other` if its `boundary` and `interior`
-        intersects in any way with those of the other.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if is
-            intersected.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         LineString([(1, 0), (1, 3)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(1, 1),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1             LINESTRING (0 0, 2 2)
-        2             LINESTRING (2 0, 0 2)
-        3                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    LINESTRING (1 0, 1 3)
-        2    LINESTRING (2 0, 0 2)
-        3              POINT (1 1)
-        4              POINT (0 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries crosses a single
-        geometry:
-
-        >>> line = LineString([(-1, 1), (3, 1)])
-        >>> s.intersects(line)
-        0    True
-        1    True
-        2    True
-        3    True
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.intersects(s2, align=True)
-        0    False
-        1     True
-        2     True
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.intersects(s2, align=False)
-        0    True
-        1    True
-        2    True
-        3    True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``crosses`` *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.disjoint
-        GeoSeries.crosses
-        GeoSeries.touches
-        GeoSeries.intersection
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2136,97 +1242,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def overlaps(self, other, align=None) -> pspd.Series:
-        """Returns True for all aligned geometries that overlap other, else False.
-
-        In the original Geopandas, Geometries overlap if they have more than one but not all
-        points in common, have the same dimension, and the intersection of the
-        interiors of the geometries has the same dimension as the geometries
-        themselves.
-
-        However, in Sedona, we return True in the case where the geometries points match.
-
-        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if
-            overlaps.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         MultiPoint([(0, 0), (0, 1)]),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 0), (0, 2)]),
-        ...         LineString([(0, 1), (1, 1)]),
-        ...         LineString([(1, 1), (3, 3)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-
-        We can check if each geometry of GeoSeries overlaps a single
-        geometry:
-
-        >>> polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        >>> s.overlaps(polygon)
-        0     True
-        1     True
-        2    False
-        3    False
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We align both GeoSeries
-        based on index values and compare elements with the same index.
-
-        >>> s.overlaps(s2)
-        0    False
-        1     True
-        2    False
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.overlaps(s2, align=False)
-        0     True
-        1    False
-        2     True
-        3    False
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``overlaps`` *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.crosses
-        GeoSeries.intersects
-
-        """
         # Note: We cannot efficiently match geopandas behavior because Sedona's ST_Overlaps returns True for equal geometries
         # ST_Overlaps(`L`, `R`) AND ST_Equals(`L`, `R`) does not work because ST_Equals errors on invalid geometries
 
@@ -2240,112 +1258,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def touches(self, other, align=None) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that touches `other`.
-
-        An object is said to touch `other` if it has at least one point in
-        common with `other` and its interior does not intersect with any part
-        of the other. Overlapping features therefore do not touch.
-
-        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if is
-            touched.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         MultiPoint([(0, 0), (0, 1)]),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (-2, 0), (0, -2)]),
-        ...         LineString([(0, 1), (1, 1)]),
-        ...         LineString([(1, 1), (3, 0)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        2             LINESTRING (0 0, 2 2)
-        3         MULTIPOINT ((0 0), (0 1))
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0 0, -2 0, 0 -2, 0 0))
-        2               LINESTRING (0 1, 1 1)
-        3               LINESTRING (1 1, 3 0)
-        4                         POINT (0 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries touches a single
-        geometry:
-
-        >>> line = LineString([(0, 0), (-1, -2)])
-        >>> s.touches(line)
-        0    True
-        1    True
-        2    True
-        3    True
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.touches(s2, align=True)
-        0    False
-        1     True
-        2     True
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.touches(s2, align=False)
-        0     True
-        1    False
-        2     True
-        3    False
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``touches`` *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.overlaps
-        GeoSeries.intersects
-
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2356,115 +1271,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def within(self, other, align=None) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that is within `other`.
-
-        An object is said to be within `other` if at least one of its points is located
-        in the `interior` and no points are located in the `exterior` of the other.
-        If either object is empty, this operation returns ``False``.
-
-        This is the inverse of `contains` in the sense that the
-        expression ``a.within(b) == b.contains(a)`` always evaluates to
-        ``True``.
-
-        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections and for geometries that are equal.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if each
-            geometry is within.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
-        ...         LineString([(0, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (0, 2)]),
-        ...         LineString([(0, 0), (0, 1)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1    POLYGON ((0 0, 1 2, 0 2, 0 0))
-        2             LINESTRING (0 0, 0 2)
-        3                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        2             LINESTRING (0 0, 0 2)
-        3             LINESTRING (0 0, 0 1)
-        4                       POINT (0 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries is within a single
-        geometry:
-
-        >>> polygon = Polygon([(0, 0), (2, 2), (0, 2)])
-        >>> s.within(polygon)
-        0     True
-        1     True
-        2    False
-        3    False
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s2.within(s)
-        0    False
-        1    False
-        2     True
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s2.within(s, align=False)
-        1     True
-        2    False
-        3     True
-        4     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries is ``within`` any element of the other one.
-
-        See also
-        --------
-        GeoSeries.contains
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2475,116 +1284,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def covers(self, other, align=None) -> pspd.Series:
-        """
-        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that is entirely covering `other`.
-
-        An object A is said to cover another object B if no points of B lie
-        in the exterior of A.
-        If either object is empty, this operation returns ``False``.
-
-        Note: Sedona's implementation instead returns False for identical geometries.
-        Sedona's behavior may also differ from Geopandas for GeometryCollections.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        See
-        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
-        for reference.
-
-        Parameters
-        ----------
-        other : Geoseries or geometric object
-            The Geoseries (elementwise) or geometric object to check is being covered.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         Point(0, 0),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
-        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
-        ...         LineString([(1, 1), (1.5, 1.5)]),
-        ...         Point(0, 0),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
-        1         POLYGON ((0 0, 2 2, 0 2, 0 0))
-        2                  LINESTRING (0 0, 2 2)
-        3                            POINT (0 0)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
-        2                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
-        3                            LINESTRING (1 1, 1.5 1.5)
-        4                                          POINT (0 0)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries covers a single
-        geometry:
-
-        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
-        >>> s.covers(poly)
-        0     True
-        1    False
-        2    False
-        3    False
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.covers(s2, align=True)
-        0    False
-        1    False
-        2    False
-        3    False
-        4    False
-        dtype: bool
-
-        >>> s.covers(s2, align=False)
-        0     True
-        1    False
-        2     True
-        3     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``covers`` any element of the other one.
-
-        See also
-        --------
-        GeoSeries.covered_by
-        GeoSeries.overlaps
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2595,116 +1297,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def covered_by(self, other, align=None) -> pspd.Series:
-        """
-        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that is entirely covered by `other`.
-
-        An object A is said to cover another object B if no points of B lie
-        in the exterior of A.
-
-        Note: Sedona's implementation instead returns False for identical geometries.
-        Sedona's behavior may differ from Geopandas for GeometryCollections.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        See
-        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
-        for reference.
-
-        Parameters
-        ----------
-        other : Geoseries or geometric object
-            The Geoseries (elementwise) or geometric object to check is being covered.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
-        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
-        ...         LineString([(1, 1), (1.5, 1.5)]),
-        ...         Point(0, 0),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         Point(0, 0),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
-        1                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
-        2                            LINESTRING (1 1, 1.5 1.5)
-        3                                          POINT (0 0)
-        dtype: geometry
-        >>>
-
-        >>> s2
-        1    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
-        2         POLYGON ((0 0, 2 2, 0 2, 0 0))
-        3                  LINESTRING (0 0, 2 2)
-        4                            POINT (0 0)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries is covered by a single
-        geometry:
-
-        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
-        >>> s.covered_by(poly)
-        0    True
-        1    True
-        2    True
-        3    True
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.covered_by(s2, align=True)
-        0    False
-        1     True
-        2     True
-        3     True
-        4    False
-        dtype: bool
-
-        >>> s.covered_by(s2, align=False)
-        0     True
-        1    False
-        2     True
-        3     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries is ``covered_by`` any element of the other one.
-
-        See also
-        --------
-        GeoSeries.covers
-        GeoSeries.overlaps
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2715,95 +1310,9 @@ class GeoSeries(GeoFrame, pspd.Series):
             align,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def distance(self, other, align=None) -> pspd.Series:
-        """Returns a ``Series`` containing the distance to aligned `other`.
-
-        The operation works on a 1-to-1 row-wise manner:
-
-        Parameters
-        ----------
-        other : Geoseries or geometric object
-            The Geoseries (elementwise) or geometric object to find the
-            distance to.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (float)
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 0), (1, 1)]),
-        ...         Polygon([(0, 0), (-1, 0), (-1, 1)]),
-        ...         LineString([(1, 1), (0, 0)]),
-        ...         Point(0, 0),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
-        ...         Point(3, 1),
-        ...         LineString([(1, 0), (2, 0)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0      POLYGON ((0 0, 1 0, 1 1, 0 0))
-        1    POLYGON ((0 0, -1 0, -1 1, 0 0))
-        2               LINESTRING (1 1, 0 0)
-        3                         POINT (0 0)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
-        2                                          POINT (3 1)
-        3                                LINESTRING (1 0, 2 0)
-        4                                          POINT (0 1)
-        dtype: geometry
-
-        We can check the distance of each geometry of GeoSeries to a single
-        geometry:
-
-        >>> point = Point(-1, 0)
-        >>> s.distance(point)
-        0    1.0
-        1    0.0
-        2    1.0
-        3    1.0
-        dtype: float64
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and use elements with the same index using
-        ``align=True`` or ignore index and use elements based on their matching
-        order using ``align=False``:
-
-        >>> s.distance(s2, align=True)
-        0         NaN
-        1    0.707107
-        2    2.000000
-        3    1.000000
-        4         NaN
-        dtype: float64
-
-        >>> s.distance(s2, align=False)
-        0    0.000000
-        1    3.162278
-        2    0.707107
-        3    1.000000
-        dtype: float64
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2819,106 +1328,6 @@ class GeoSeries(GeoFrame, pspd.Series):
     def intersection(
         self, other: Union["GeoSeries", BaseGeometry], align: Union[bool, None] = None
     ) -> "GeoSeries":
-        """Returns a ``GeoSeries`` of the intersection of points in each
-        aligned geometry with `other`.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : Geoseries or geometric object
-            The Geoseries (elementwise) or geometric object to find the
-            intersection with.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        GeoSeries
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         LineString([(0, 0), (2, 2)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(1, 0), (1, 3)]),
-        ...         LineString([(2, 0), (0, 2)]),
-        ...         Point(1, 1),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 6),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        2             LINESTRING (0 0, 2 2)
-        3             LINESTRING (2 0, 0 2)
-        4                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        2             LINESTRING (1 0, 1 3)
-        3             LINESTRING (2 0, 0 2)
-        4                       POINT (1 1)
-        5                       POINT (0 1)
-        dtype: geometry
-
-        We can also do intersection of each geometry and a single
-        shapely geometry:
-
-        >>> s.intersection(Polygon([(0, 0), (1, 1), (0, 1)]))
-        0    POLYGON ((0 0, 0 1, 1 1, 0 0))
-        1    POLYGON ((0 0, 0 1, 1 1, 0 0))
-        2             LINESTRING (0 0, 1 1)
-        3                       POINT (1 1)
-        4                       POINT (0 1)
-        dtype: geometry
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s.intersection(s2, align=True)
-        0                              None
-        1    POLYGON ((0 0, 0 1, 1 1, 0 0))
-        2                       POINT (1 1)
-        3             LINESTRING (2 0, 0 2)
-        4                       POINT EMPTY
-        5                              None
-        dtype: geometry
-
-        >>> s.intersection(s2, align=False)
-        0    POLYGON ((0 0, 0 1, 1 1, 0 0))
-        1             LINESTRING (1 1, 1 2)
-        2                       POINT (1 1)
-        3                       POINT (1 1)
-        4                       POINT (0 1)
-        dtype: geometry
-
-
-        See Also
-        --------
-        GeoSeries.difference
-        GeoSeries.symmetric_difference
-        GeoSeries.union
-        """
-
         other_series, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -2933,100 +1342,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         return result
 
     def snap(self, other, tolerance, align=None) -> "GeoSeries":
-        """Snap the vertices and segments of the geometry to vertices of the reference.
-
-        Vertices and segments of the input geometry are snapped to vertices of the
-        reference geometry, returning a new geometry; the input geometries are not
-        modified. The result geometry is the input geometry with the vertices and
-        segments snapped. If no snapping occurs then the input geometry is returned
-        unchanged. The tolerance is used to control where snapping is performed.
-
-        Where possible, this operation tries to avoid creating invalid geometries;
-        however, it does not guarantee that output geometries will be valid. It is
-        the responsibility of the caller to check for and handle invalid geometries.
-
-        Because too much snapping can result in invalid geometries being created,
-        heuristics are used to determine the number and location of snapped
-        vertices that are likely safe to snap. These heuristics may omit
-        some potential snaps that are otherwise within the tolerance.
-
-        Note: Sedona's result may differ slightly from geopandas's snap() result
-        because of small differences between the underlying engines being used.
-
-        The operation works in a 1-to-1 row-wise manner:
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The Geoseries (elementwise) or geometric object to snap to.
-        tolerance : float or array like
-            Maximum distance between vertices that shall be snapped
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        GeoSeries
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Point(0.5, 2.5),
-        ...         LineString([(0.1, 0.1), (0.49, 0.51), (1.01, 0.89)]),
-        ...         Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]),
-        ...     ],
-        ... )
-        >>> s
-        0                               POINT (0.5 2.5)
-        1    LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
-        2       POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
-        dtype: geometry
-
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Point(0, 2),
-        ...         LineString([(0, 0), (0.5, 0.5), (1.0, 1.0)]),
-        ...         Point(8, 10),
-        ...     ],
-        ...     index=range(1, 4),
-        ... )
-        >>> s2
-        1                       POINT (0 2)
-        2    LINESTRING (0 0, 0.5 0.5, 1 1)
-        3                      POINT (8 10)
-        dtype: geometry
-
-        We can snap each geometry to a single shapely geometry:
-
-        >>> s.snap(Point(0, 2), tolerance=1)
-        0                                     POINT (0 2)
-        1      LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
-        2    POLYGON ((0 0, 0 2, 0 10, 10 10, 10 0, 0 0))
-        dtype: geometry
-
-        We can also snap two GeoSeries to each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and snap elements with the same index using
-        ``align=True`` or ignore index and snap elements based on their matching
-        order using ``align=False``:
-
-        >>> s.snap(s2, tolerance=1, align=True)
-        0                                                 None
-        1           LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
-        2    POLYGON ((0.5 0.5, 1 1, 0 10, 10 10, 10 0, 0.5...
-        3                                                 None
-        dtype: geometry
-
-        >>> s.snap(s2, tolerance=1, align=False)
-        0                                      POINT (0 2)
-        1                   LINESTRING (0 0, 0.5 0.5, 1 1)
-        2    POLYGON ((0 0, 0 10, 8 10, 10 10, 10 0, 0 0))
-        dtype: geometry
-        """
         if not isinstance(tolerance, (float, int)):
             raise NotImplementedError(
                 "Array-like values for tolerance are not supported yet."
@@ -3055,6 +1370,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         align: Union[bool, None],
         returns_geom: bool = False,
         default_val: Any = None,
+        keep_name: bool = False,
     ):
         """
         Helper function to perform a row-wise operation on two GeoSeries.
@@ -3105,18 +1421,12 @@ class GeoSeries(GeoFrame, pspd.Series):
                 F.col("L").isNull() | F.col("R").isNull(),
                 default_val,
             ).otherwise(spark_col)
-            # The above is equivalent to the following:
-            f"""
-                CASE
-                    WHEN `L` IS NULL OR `R` IS NULL THEN {default_val}
-                    ELSE {spark_col}
-                END
-            """
 
         return self._query_geometry_column(
             spark_col,
             joined_df,
             returns_geom=returns_geom,
+            keep_name=keep_name,
         )
 
     def intersection_all(self):
@@ -3128,116 +1438,6 @@ class GeoSeries(GeoFrame, pspd.Series):
     # ============================================================================
 
     def contains(self, other, align=None) -> pspd.Series:
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-        each aligned geometry that contains `other`.
-
-        An object is said to contain `other` if at least one point of `other` lies in
-        the interior and no points of `other` lie in the exterior of the object.
-        (Therefore, any given polygon does not contain its own boundary - there is not
-        any point that lies in the interior.)
-        If either object is empty, this operation returns ``False``.
-
-        This is the inverse of `within` in the sense that the expression
-        ``a.contains(b) == b.within(a)`` always evaluates to ``True``.
-
-        Note: Sedona's implementation instead returns False for identical geometries.
-
-        The operation works on a 1-to-1 row-wise manner.
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to test if it
-            is contained.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
-            If False, the order of elements is preserved.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Polygon, LineString, Point
-        >>> s = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
-        ...         LineString([(0, 0), (0, 2)]),
-        ...         LineString([(0, 0), (0, 1)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(0, 4),
-        ... )
-        >>> s2 = GeoSeries(
-        ...     [
-        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
-        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
-        ...         LineString([(0, 0), (0, 2)]),
-        ...         Point(0, 1),
-        ...     ],
-        ...     index=range(1, 5),
-        ... )
-
-        >>> s
-        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
-        1             LINESTRING (0 0, 0 2)
-        2             LINESTRING (0 0, 0 1)
-        3                       POINT (0 1)
-        dtype: geometry
-
-        >>> s2
-        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
-        2    POLYGON ((0 0, 1 2, 0 2, 0 0))
-        3             LINESTRING (0 0, 0 2)
-        4                       POINT (0 1)
-        dtype: geometry
-
-        We can check if each geometry of GeoSeries contains a single
-        geometry:
-
-        >>> point = Point(0, 1)
-        >>> s.contains(point)
-        0    False
-        1     True
-        2    False
-        3     True
-        dtype: bool
-
-        We can also check two GeoSeries against each other, row by row.
-        The GeoSeries above have different indices. We can either align both GeoSeries
-        based on index values and compare elements with the same index using
-        ``align=True`` or ignore index and compare elements based on their matching
-        order using ``align=False``:
-
-        >>> s2.contains(s, align=True)
-        0    False
-        1    False
-        2    False
-        3     True
-        4    False
-        dtype: bool
-
-        >>> s2.contains(s, align=False)
-        1     True
-        2    False
-        3     True
-        4     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries ``contains`` any element of the other one.
-
-        See also
-        --------
-        GeoSeries.contains_properly
-        GeoSeries.within
-        """
-
         other, extended = self._make_series_of_val(other)
         align = False if extended else align
 
@@ -3249,7 +1449,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=False,
             default_val=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
     def contains_properly(self, other, align=None):
         # Implementation of the abstract method
@@ -3270,29 +1470,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         single_sided=False,
         **kwargs,
     ) -> "GeoSeries":
-        """
-        Returns a GeoSeries of geometries representing all points within a given distance of each geometric object.
-
-        Parameters
-        ----------
-        distance : float
-            The distance to buffer around each geometry.
-        resolution : int, optional, default 16
-            The resolution of the buffer around each geometry.
-        cap_style : str, optional, default "round"
-            The style of the buffer's cap (round, flat, or square).
-        join_style : str, optional, default "round"
-            The style of the buffer's join (round, mitre, or bevel).
-        mitre_limit : float, optional, default 5.0
-            The mitre limit for the buffer's join style.
-        single_sided : bool, optional, default False
-            Whether to create a single-sided buffer.
-
-        Returns
-        -------
-        GeoSeries
-            A GeoSeries of buffered geometries.
-        """
         spark_col = stf.ST_Buffer(self.spark.column, distance)
         return self._query_geometry_column(
             spark_col,
@@ -3300,64 +1477,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
 
     def simplify(self, tolerance=None, preserve_topology=True) -> "GeoSeries":
-        """Returns a ``GeoSeries`` containing a simplified representation of
-        each geometry.
-
-        The algorithm (Douglas-Peucker) recursively splits the original line
-        into smaller parts and connects these parts' endpoints
-        by a straight line. Then, it removes all points whose distance
-        to the straight line is smaller than `tolerance`. It does not
-        move any points and it always preserves endpoints of
-        the original line or polygon.
-        See https://shapely.readthedocs.io/en/latest/manual.html#object.simplify
-        for details
-
-        Simplifies individual geometries independently, without considering
-        the topology of a potential polygonal coverage. If you would like to treat
-        the ``GeoSeries`` as a coverage and simplify its edges, while preserving the
-        coverage topology, see :meth:`simplify_coverage`.
-
-        Parameters
-        ----------
-        tolerance : float
-            All parts of a simplified geometry will be no more than
-            `tolerance` distance from the original. It has the same units
-            as the coordinate reference system of the GeoSeries.
-            For example, using `tolerance=100` in a projected CRS with meters
-            as units means a distance of 100 meters in reality.
-        preserve_topology: bool (default True)
-            False uses a quicker algorithm, but may produce self-intersecting
-            or otherwise invalid geometries.
-
-        Notes
-        -----
-        Invalid geometric objects may result from simplification that does not
-        preserve topology and simplification may be sensitive to the order of
-        coordinates: two geometries differing only in order of coordinates may be
-        simplified differently.
-
-        See also
-        --------
-        simplify_coverage : simplify geometries using coverage simplification
-
-        Examples
-        --------
-        >>> from sedona.geopandas import GeoSeries
-        >>> from shapely.geometry import Point, LineString
-        >>> s = GeoSeries(
-        ...     [Point(0, 0).buffer(1), LineString([(0, 0), (1, 10), (0, 20)])]
-        ... )
-        >>> s
-        0    POLYGON ((1 0, 0.99518 -0.09802, 0.98079 -0.19...
-        1                         LINESTRING (0 0, 1 10, 0 20)
-        dtype: geometry
-
-        >>> s.simplify(1)
-        0    POLYGON ((0 1, 0 -1, -1 0, 0 1))
-        1              LINESTRING (0 0, 0 20)
-        dtype: geometry
-        """
-
         spark_expr = (
             stf.ST_SimplifyPreserveTopology(self.spark.column, tolerance)
             if preserve_topology
@@ -3417,6 +1536,7 @@ class GeoSeries(GeoFrame, pspd.Series):
     def geometry(self) -> "GeoSeries":
         return self
 
+    # GeoSeries-only (not in GeoDataFrame)
     @property
     def x(self) -> pspd.Series:
         """Return the x location of point geometries in a GeoSeries
@@ -3450,6 +1570,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=False,
         )
 
+    # GeoSeries-only (not in GeoDataFrame)
     @property
     def y(self) -> pspd.Series:
         """Return the y location of point geometries in a GeoSeries
@@ -3484,6 +1605,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=False,
         )
 
+    # GeoSeries-only (not in GeoDataFrame)
     @property
     def z(self) -> pspd.Series:
         """Return the z location of point geometries in a GeoSeries
@@ -3518,6 +1640,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             returns_geom=False,
         )
 
+    # GeoSeries-only (not in GeoDataFrame)
     @property
     def m(self) -> pspd.Series:
         raise NotImplementedError("GeoSeries.m() is not implemented yet.")
@@ -3526,6 +1649,7 @@ class GeoSeries(GeoFrame, pspd.Series):
     # CONSTRUCTION METHODS
     # ============================================================================
 
+    # GeoSeries-only (not in GeoDataFrame)
     @classmethod
     def from_file(
         cls, filename: str, format: Union[str, None] = None, **kwargs
@@ -3558,6 +1682,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         df = sgpd.io.read_file(filename, format, **kwargs)
         return GeoSeries(df.geometry, crs=df.crs)
 
+    # GeoSeries-only (not in GeoDataFrame)
     @classmethod
     def from_wkb(
         cls,
@@ -3636,7 +1761,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         schema = StructType([StructField("data", BinaryType(), True)])
         return cls._create_from_select(
-            f"ST_GeomFromWKB(`data`)",
+            stc.ST_GeomFromWKB(F.col("data")),
             data,
             schema,
             index,
@@ -3644,6 +1769,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             **kwargs,
         )
 
+    # GeoSeries-only (not in GeoDataFrame)
     @classmethod
     def from_wkt(
         cls,
@@ -3715,7 +1841,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         schema = StructType([StructField("data", StringType(), True)])
         return cls._create_from_select(
-            f"ST_GeomFromText(`data`)",
+            stc.ST_GeomFromText(F.col("data")),
             data,
             schema,
             index,
@@ -3723,6 +1849,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             **kwargs,
         )
 
+    # GeoSeries-only (not in GeoDataFrame)
     @classmethod
     def from_xy(cls, x, y, z=None, index=None, crs=None, **kwargs) -> "GeoSeries":
         """
@@ -3781,11 +1908,11 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         if z:
             data = list(zip(x, y, z))
-            select = f"ST_PointZ(`x`, `y`, `z`)"
+            select = stc.ST_PointZ(F.col("x"), F.col("y"), F.col("z"))
             schema.add(StructField("z", DoubleType(), True))
         else:
             data = list(zip(x, y))
-            select = f"ST_Point(`x`, `y`)"
+            select = stc.ST_Point(F.col("x"), F.col("y"))
 
         geoseries = cls._create_from_select(
             select,
@@ -3867,7 +1994,7 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @classmethod
     def _create_from_select(
-        cls, select: str, data, schema, index, crs, **kwargs
+        cls, spark_col: PySparkColumn, data, schema, index, crs, **kwargs
     ) -> "GeoSeries":
 
         from pyspark.pandas.utils import default_session
@@ -3877,7 +2004,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         if isinstance(data, list) and not isinstance(data[0], (tuple, list)):
             data = [(obj,) for obj in data]
 
-        select = f"{select} as geometry"
+        name = kwargs.get("name", SPARK_DEFAULT_SERIES_NAME)
 
         if isinstance(data, pspd.Series):
             spark_df = data._internal.spark_frame
@@ -3888,29 +2015,26 @@ class GeoSeries(GeoFrame, pspd.Series):
         else:
             spark_df = default_session().createDataFrame(data, schema=schema)
 
-        spark_df = spark_df.selectExpr(select)
+        spark_df = spark_df.select(spark_col.alias(name))
 
         internal = InternalFrame(
             spark_frame=spark_df,
             index_spark_columns=None,
-            column_labels=[("geometry",)],
-            data_spark_columns=[scol_for(spark_df, "geometry")],
-            data_fields=[
-                InternalField(np.dtype("object"), spark_df.schema["geometry"])
-            ],
-            column_label_names=[("geometry",)],
+            column_labels=[(name,)],
+            data_spark_columns=[scol_for(spark_df, name)],
+            data_fields=[InternalField(np.dtype("object"), spark_df.schema[name])],
+            column_label_names=[(name,)],
         )
-        return GeoSeries(
-            first_series(PandasOnSparkDataFrame(internal)),
-            index,
-            crs=crs,
-            name=kwargs.get("name", None),
-        )
+        ps_series = first_series(PandasOnSparkDataFrame(internal))
+        name = None if name == SPARK_DEFAULT_SERIES_NAME else name
+        ps_series.rename(name, inplace=True)
+        return GeoSeries(ps_series, index, crs=crs)
 
     # ============================================================================
     # DATA ACCESS AND MANIPULATION
     # ============================================================================
 
+    # GeoSeries-only (not in GeoDataFrame)
     def isna(self) -> pspd.Series:
         """
         Detect missing values.
@@ -3950,12 +2074,14 @@ class GeoSeries(GeoFrame, pspd.Series):
             spark_expr,
             returns_geom=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
+    # GeoSeries-only (not in GeoDataFrame)
     def isnull(self) -> pspd.Series:
         """Alias for `isna` method. See `isna` for more detail."""
         return self.isna()
 
+    # GeoSeries-only (not in GeoDataFrame)
     def notna(self) -> pspd.Series:
         """
         Detect non-missing values.
@@ -3996,12 +2122,14 @@ class GeoSeries(GeoFrame, pspd.Series):
             spark_expr,
             returns_geom=False,
         )
-        return to_bool(result)
+        return _to_bool(result)
 
+    # GeoSeries-only (not in GeoDataFrame)
     def notnull(self) -> pspd.Series:
         """Alias for `notna` method. See `notna` for more detail."""
         return self.notna()
 
+    # GeoSeries-only (not in GeoDataFrame)
     def fillna(
         self, value=None, inplace: bool = False, limit=None, **kwargs
     ) -> Union["GeoSeries", None]:
@@ -4013,8 +2141,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         value : shapely geometry or GeoSeries, default None
             If None is passed, NA values will be filled with GEOMETRYCOLLECTION EMPTY.
             If a shapely geometry object is passed, it will be
-            used to fill all missing values. If a ``GeoSeries`` or ``GeometryArray``
-            are passed, missing values will be filled based on the corresponding index
+            used to fill all missing values. If a ``GeoSeries``
+            is passed, missing values will be filled based on the corresponding index
             locations. If pd.NA or np.nan are passed, values will be filled with
             ``None`` (not GEOMETRYCOLLECTION EMPTY).
         limit : int, default None
@@ -4080,7 +2208,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.isna : detect missing values
         """
         from shapely.geometry.base import BaseGeometry
-        from geopandas.array import GeometryArray
 
         # TODO: Implement limit https://github.com/apache/sedona/issues/2068
         if limit:
@@ -4104,7 +2231,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             other, extended = self._make_series_of_val(value)
             align = False if extended else align
 
-        elif isinstance(value, (GeoSeries, GeometryArray, gpd.GeoSeries)):
+        elif isinstance(value, (GeoSeries, gpd.GeoSeries)):
 
             if not isinstance(value, GeoSeries):
                 value = GeoSeries(value)
@@ -4123,6 +2250,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             align=align,
             returns_geom=True,
             default_val=None,
+            keep_name=True,
         )
 
         if inplace:
@@ -4242,33 +2370,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def bounds(self) -> pspd.DataFrame:
-        """Returns a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
-        ``maxy`` values containing the bounds for each geometry.
-
-        See ``GeoSeries.total_bounds`` for the limits of the entire series.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Point, Polygon, LineString
-        >>> d = {'geometry': [Point(2, 1), Polygon([(0, 0), (1, 1), (1, 0)]),
-        ... LineString([(0, 1), (1, 2)])]}
-        >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
-        >>> gdf.bounds
-           minx  miny  maxx  maxy
-        0   2.0   1.0   2.0   1.0
-        1   0.0   0.0   1.0   1.0
-        2   0.0   1.0   1.0   2.0
-
-        You can assign the bounds to the ``GeoDataFrame`` as:
-
-        >>> import pandas as pd
-        >>> gdf = pd.concat([gdf, gdf.bounds], axis=1)
-        >>> gdf
-                                geometry  minx  miny  maxx  maxy
-        0                     POINT (2 1)   2.0   1.0   2.0   1.0
-        1  POLYGON ((0 0, 1 1, 1 0, 0 0))   0.0   0.0   1.0   1.0
-        2           LINESTRING (0 1, 1 2)   0.0   1.0   1.0   2.0
-        """
         selects = [
             stf.ST_XMin(self.spark.column).alias("minx"),
             stf.ST_YMin(self.spark.column).alias("miny"),
@@ -4295,21 +2396,6 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @property
     def total_bounds(self):
-        """Returns a tuple containing ``minx``, ``miny``, ``maxx``, ``maxy``
-        values for the bounds of the series as a whole.
-
-        See ``GeoSeries.bounds`` for the bounds of the geometries contained in
-        the series.
-
-        Examples
-        --------
-        >>> from shapely.geometry import Point, Polygon, LineString
-        >>> d = {'geometry': [Point(3, -1), Polygon([(0, 0), (1, 1), (1, 0)]),
-        ... LineString([(0, 1), (1, 2)])]}
-        >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
-        >>> gdf.total_bounds
-        array([ 0., -1.,  3.,  2.])
-        """
         import numpy as np
         import warnings
         from pyspark.sql import functions as F
@@ -4342,12 +2428,9 @@ class GeoSeries(GeoFrame, pspd.Series):
                 )
             )
 
+    # GeoSeries-only (not in GeoDataFrame)
     def estimate_utm_crs(self, datum_name: str = "WGS 84") -> "CRS":
         """Returns the estimated UTM CRS based on the bounds of the dataset.
-
-        .. versionadded:: 0.9
-
-        .. note:: Requires pyproj 3+
 
         Parameters
         ----------
@@ -4493,7 +2576,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         --------
         GeoSeries.to_file : write GeoSeries to file
         """
-        return self._to_geoframe(name="geometry").to_json(
+        return self.to_geoframe(name="geometry").to_json(
             na="null", show_bbox=show_bbox, drop_id=drop_id, to_wgs84=to_wgs84, **kwargs
         )
 
@@ -4747,7 +2830,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         >>> gdf = GeoDataFrame({"geometry": [Point(0, 0)]}, index=["a", "b"])
         >>> gdf.to_file(gdf, driver="geoparquet")
         """
-        self._to_geoframe().to_file(path, driver, index=index, **kwargs)
+        self.to_geoframe().to_file(path, driver, index=index, **kwargs)
 
     def to_parquet(self, path, **kwargs):
         """
@@ -4758,7 +2841,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         - kwargs: Any
             Additional arguments to pass to the Sedona DataFrame output function.
         """
-        self._to_geoframe().to_file(path, driver="geoparquet", **kwargs)
+        self.to_geoframe().to_file(path, driver="geoparquet", **kwargs)
 
     # -----------------------------------------------------------------------------
     # # Utils
@@ -4787,10 +2870,10 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         else:
             return value, False
 
-    def _to_geoframe(self, name=None):
+    def to_geoframe(self, name=None):
         if name is not None:
             renamed = self.rename(name)
-        elif self._column_label is None:
+        elif self._column_label is None or self._column_label == (None,):
             renamed = self.rename("geometry")
         else:
             renamed = self
@@ -4808,7 +2891,7 @@ def _get_series_col_name(ps_series: pspd.Series) -> str:
     return ps_series.name if ps_series.name else SPARK_DEFAULT_SERIES_NAME
 
 
-def to_bool(ps_series: pspd.Series, default: bool = False) -> pspd.Series:
+def _to_bool(ps_series: pspd.Series, default: bool = False) -> pspd.Series:
     """
     Cast a ps.Series to bool type if it's not one, converting None values to the default value.
     """
@@ -4817,16 +2900,3 @@ def to_bool(ps_series: pspd.Series, default: bool = False) -> pspd.Series:
         ps_series.fillna(default, inplace=True)
 
     return ps_series
-
-
-def _to_geo_series(df: PandasOnSparkSeries) -> GeoSeries:
-    """
-    Get the first Series from the DataFrame.
-
-    Parameters:
-    - df: The input DataFrame.
-
-    Returns:
-    - GeoSeries: The first Series from the DataFrame.
-    """
-    return GeoSeries(data=df)

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -2933,6 +2933,122 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
         return result
 
+    def snap(self, other, tolerance, align=None) -> "GeoSeries":
+        """Snap the vertices and segments of the geometry to vertices of the reference.
+
+        Vertices and segments of the input geometry are snapped to vertices of the
+        reference geometry, returning a new geometry; the input geometries are not
+        modified. The result geometry is the input geometry with the vertices and
+        segments snapped. If no snapping occurs then the input geometry is returned
+        unchanged. The tolerance is used to control where snapping is performed.
+
+        Where possible, this operation tries to avoid creating invalid geometries;
+        however, it does not guarantee that output geometries will be valid. It is
+        the responsibility of the caller to check for and handle invalid geometries.
+
+        Because too much snapping can result in invalid geometries being created,
+        heuristics are used to determine the number and location of snapped
+        vertices that are likely safe to snap. These heuristics may omit
+        some potential snaps that are otherwise within the tolerance.
+
+        Note: Sedona's result may differ slightly from geopandas's snap() result
+        because of small differences between the underlying engines being used.
+
+        The operation works in a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The Geoseries (elementwise) or geometric object to snap to.
+        tolerance : float or array like
+            Maximum distance between vertices that shall be snapped
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        GeoSeries
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Point(0.5, 2.5),
+        ...         LineString([(0.1, 0.1), (0.49, 0.51), (1.01, 0.89)]),
+        ...         Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]),
+        ...     ],
+        ... )
+        >>> s
+        0                               POINT (0.5 2.5)
+        1    LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2       POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Point(0, 2),
+        ...         LineString([(0, 0), (0.5, 0.5), (1.0, 1.0)]),
+        ...         Point(8, 10),
+        ...     ],
+        ...     index=range(1, 4),
+        ... )
+        >>> s2
+        1                       POINT (0 2)
+        2    LINESTRING (0 0, 0.5 0.5, 1 1)
+        3                      POINT (8 10)
+        dtype: geometry
+
+        We can snap each geometry to a single shapely geometry:
+
+        >>> s.snap(Point(0, 2), tolerance=1)
+        0                                     POINT (0 2)
+        1      LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2    POLYGON ((0 0, 0 2, 0 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+
+        We can also snap two GeoSeries to each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and snap elements with the same index using
+        ``align=True`` or ignore index and snap elements based on their matching
+        order using ``align=False``:
+
+        >>> s.snap(s2, tolerance=1, align=True)
+        0                                                 None
+        1           LINESTRING (0.1 0.1, 0.49 0.51, 1.01 0.89)
+        2    POLYGON ((0.5 0.5, 1 1, 0 10, 10 10, 10 0, 0.5...
+        3                                                 None
+        dtype: geometry
+
+        >>> s.snap(s2, tolerance=1, align=False)
+        0                                      POINT (0 2)
+        1                   LINESTRING (0 0, 0.5 0.5, 1 1)
+        2    POLYGON ((0 0, 0 10, 8 10, 10 10, 10 0, 0 0))
+        dtype: geometry
+        """
+        if not isinstance(tolerance, (float, int)):
+            raise NotImplementedError(
+                "Array-like values for tolerance are not supported yet."
+            )
+
+        # Both sgpd and gpd implementations simply call the snap functions
+        # in JTS and GEOs, respectively. The results often differ slightly, but these
+        # must be differences inside of the engines themselves.
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stf.ST_Snap(F.col("L"), F.col("R"), tolerance)
+        result = self._row_wise_operation(
+            spark_expr,
+            other_series,
+            align,
+            returns_geom=True,
+        )
+        return result
+
     def _row_wise_operation(
         self,
         spark_col: PySparkColumn,
@@ -3183,6 +3299,73 @@ class GeoSeries(GeoFrame, pspd.Series):
             spark_col,
             returns_geom=True,
         )
+
+    def simplify(self, tolerance=None, preserve_topology=True) -> "GeoSeries":
+        """Returns a ``GeoSeries`` containing a simplified representation of
+        each geometry.
+
+        The algorithm (Douglas-Peucker) recursively splits the original line
+        into smaller parts and connects these parts' endpoints
+        by a straight line. Then, it removes all points whose distance
+        to the straight line is smaller than `tolerance`. It does not
+        move any points and it always preserves endpoints of
+        the original line or polygon.
+        See https://shapely.readthedocs.io/en/latest/manual.html#object.simplify
+        for details
+
+        Simplifies individual geometries independently, without considering
+        the topology of a potential polygonal coverage. If you would like to treat
+        the ``GeoSeries`` as a coverage and simplify its edges, while preserving the
+        coverage topology, see :meth:`simplify_coverage`.
+
+        Parameters
+        ----------
+        tolerance : float
+            All parts of a simplified geometry will be no more than
+            `tolerance` distance from the original. It has the same units
+            as the coordinate reference system of the GeoSeries.
+            For example, using `tolerance=100` in a projected CRS with meters
+            as units means a distance of 100 meters in reality.
+        preserve_topology: bool (default True)
+            False uses a quicker algorithm, but may produce self-intersecting
+            or otherwise invalid geometries.
+
+        Notes
+        -----
+        Invalid geometric objects may result from simplification that does not
+        preserve topology and simplification may be sensitive to the order of
+        coordinates: two geometries differing only in order of coordinates may be
+        simplified differently.
+
+        See also
+        --------
+        simplify_coverage : simplify geometries using coverage simplification
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point, LineString
+        >>> s = GeoSeries(
+        ...     [Point(0, 0).buffer(1), LineString([(0, 0), (1, 10), (0, 20)])]
+        ... )
+        >>> s
+        0    POLYGON ((1 0, 0.99518 -0.09802, 0.98079 -0.19...
+        1                         LINESTRING (0 0, 1 10, 0 20)
+        dtype: geometry
+
+        >>> s.simplify(1)
+        0    POLYGON ((0 1, 0 -1, -1 0, 0 1))
+        1              LINESTRING (0 0, 0 20)
+        dtype: geometry
+        """
+
+        spark_expr = (
+            stf.ST_SimplifyPreserveTopology(self.spark.column, tolerance)
+            if preserve_topology
+            else stf.ST_Simplify(self.spark.column, tolerance)
+        )
+
+        return self._query_geometry_column(spark_expr)
 
     def to_parquet(self, path, **kwargs):
         """

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -701,9 +701,14 @@ class GeoSeries(GeoFrame, pspd.Series):
 
             index_spark_columns = [scol_for(df, SPARK_DEFAULT_INDEX_NAME)]
             index_fields = [self._internal.index_fields[0]]
+            sdf = df.select(
+                col_expr,
+                scol_for(df, SPARK_DEFAULT_INDEX_NAME),
+                scol_for(df, NATURAL_ORDER_COLUMN_NAME),
+            ).orderBy(SPARK_DEFAULT_INDEX_NAME)
         # else if is_aggr, we don't select the index columns
-
-        sdf = df.select(*exprs)
+        else:
+            sdf = df.select(*exprs)
 
         internal = self._internal.copy(
             spark_frame=sdf,

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -493,12 +493,17 @@ class GeoSeries(GeoFrame, pspd.Series):
         if len(self) == 0:
             return None
 
-        tmp = self._process_geometry_column("ST_SRID", rename="crs", returns_geom=False)
-        ps_series = tmp.take([0])
-        srid = ps_series.iloc[0]
+        tmp_series: pspd.Series = self._process_geometry_column(
+            "ST_SRID", rename="crs", returns_geom=False
+        )
+
+        # All geometries should have the same srid
+        # so we just take the srid of the first non-null element
+        first_idx = tmp_series.first_valid_index()
+        srid = tmp_series[first_idx] if first_idx is not None else 0
 
         # Sedona returns 0 if doesn't exist
-        return CRS.from_user_input(srid) if srid != 0 and not pd.isna(srid) else None
+        return CRS.from_user_input(srid) if srid != 0 else None
 
     @crs.setter
     def crs(self, value: Union["CRS", None]):

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -46,6 +46,7 @@ from sedona.geopandas._typing import Label
 from sedona.geopandas.base import GeoFrame
 from sedona.geopandas.geodataframe import GeoDataFrame
 from sedona.geopandas.sindex import SpatialIndex
+from packaging.version import parse as parse_version
 
 from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,  # __index_level_0__
@@ -439,6 +440,8 @@ class GeoSeries(GeoFrame, pspd.Series):
                     fastpath=fastpath,
                 )
 
+            pd_series = pd_series.astype(object)
+
             # initialize the parent class pyspark Series with the pandas Series
             super().__init__(data=pd_series)
 
@@ -623,6 +626,10 @@ class GeoSeries(GeoFrame, pspd.Series):
             crs = CRS.from_epsg(epsg)
 
         curr_crs = self.crs
+
+        # If CRS is the same, do nothing
+        if curr_crs == crs:
+            return
 
         if not allow_override and curr_crs is not None and not curr_crs == crs:
             raise ValueError(
@@ -3621,7 +3628,55 @@ class GeoSeries(GeoFrame, pspd.Series):
 
     @classmethod
     def from_arrow(cls, arr, **kwargs) -> "GeoSeries":
-        raise NotImplementedError("GeoSeries.from_arrow() is not implemented yet.")
+        """
+        Construct a GeoSeries from a Arrow array object with a GeoArrow
+        extension type.
+
+        See https://geoarrow.org/ for details on the GeoArrow specification.
+
+        This functions accepts any Arrow array object implementing
+        the `Arrow PyCapsule Protocol`_ (i.e. having an ``__arrow_c_array__``
+        method).
+
+        .. _Arrow PyCapsule Protocol: https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
+
+        Note: Requires geopandas versions >= 1.0.0 to use with Sedona.
+
+        Parameters
+        ----------
+        arr : pyarrow.Array, Arrow array
+            Any array object implementing the Arrow PyCapsule Protocol
+            (i.e. has an ``__arrow_c_array__`` or ``__arrow_c_stream__``
+            method). The type of the array should be one of the
+            geoarrow geometry types.
+        **kwargs
+            Other parameters passed to the GeoSeries constructor.
+
+        Returns
+        -------
+        GeoSeries
+
+        See Also
+        --------
+        GeoSeries.to_arrow
+        GeoDataFrame.from_arrow
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> import geoarrow.pyarrow as ga
+        >>> array = ga.as_geoarrow([None, "POLYGON ((0 0, 1 1, 0 1, 0 0))", "LINESTRING (0 0, -1 1, 0 -1)"])
+        >>> geoseries = GeoSeries.from_arrow(array)
+        >>> geoseries
+        0                              None
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2      LINESTRING (0 0, -1 1, 0 -1)
+        dtype: geometry
+
+        """
+        gpd_series = gpd.GeoSeries.from_arrow(arr, **kwargs)
+        return GeoSeries(gpd_series)
 
     @classmethod
     def _create_from_select(
@@ -4210,7 +4265,56 @@ class GeoSeries(GeoFrame, pspd.Series):
         to_wgs84: bool = False,
         **kwargs,
     ) -> str:
-        raise NotImplementedError("GeoSeries.to_json() is not implemented yet.")
+        """
+        Returns a GeoJSON string representation of the GeoSeries.
+
+        Parameters
+        ----------
+        show_bbox : bool, optional, default: True
+            Include bbox (bounds) in the geojson
+        drop_id : bool, default: False
+            Whether to retain the index of the GeoSeries as the id property
+            in the generated GeoJSON. Default is False, but may want True
+            if the index is just arbitrary row numbers.
+        to_wgs84: bool, optional, default: False
+            If the CRS is set on the active geometry column it is exported as
+            WGS84 (EPSG:4326) to meet the `2016 GeoJSON specification
+            <https://tools.ietf.org/html/rfc7946>`_.
+            Set to True to force re-projection and set to False to ignore CRS. False by
+            default.
+
+        *kwargs* that will be passed to json.dumps().
+
+        Returns
+        -------
+        JSON string
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point
+        >>> s = GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+        >>> s
+        0    POINT (1 1)
+        1    POINT (2 2)
+        2    POINT (3 3)
+        dtype: geometry
+
+        >>> s.to_json()
+        '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "pr\
+operties": {}, "geometry": {"type": "Point", "coordinates": [1.0, 1.0]}, "bbox": [1.0,\
+ 1.0, 1.0, 1.0]}, {"id": "1", "type": "Feature", "properties": {}, "geometry": {"type"\
+: "Point", "coordinates": [2.0, 2.0]}, "bbox": [2.0, 2.0, 2.0, 2.0]}, {"id": "2", "typ\
+e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3.0, 3.\
+0]}, "bbox": [3.0, 3.0, 3.0, 3.0]}], "bbox": [1.0, 1.0, 3.0, 3.0]}'
+
+        See Also
+        --------
+        GeoSeries.to_file : write GeoSeries to file
+        """
+        return self._to_geoframe(name="geometry").to_json(
+            na="null", show_bbox=show_bbox, drop_id=drop_id, to_wgs84=to_wgs84, **kwargs
+        )
 
     def to_wkb(self, hex: bool = False, **kwargs) -> pspd.Series:
         """
@@ -4313,7 +4417,79 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
 
     def to_arrow(self, geometry_encoding="WKB", interleaved=True, include_z=None):
-        raise NotImplementedError("GeoSeries.to_arrow() is not implemented yet.")
+        """Encode a GeoSeries to GeoArrow format.
+
+        See https://geoarrow.org/ for details on the GeoArrow specification.
+
+        This functions returns a generic Arrow array object implementing
+        the `Arrow PyCapsule Protocol`_ (i.e. having an ``__arrow_c_array__``
+        method). This object can then be consumed by your Arrow implementation
+        of choice that supports this protocol.
+
+        .. _Arrow PyCapsule Protocol: https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
+
+        Note: Requires geopandas versions >= 1.0.0 to use with Sedona.
+
+        Parameters
+        ----------
+        geometry_encoding : {'WKB', 'geoarrow' }, default 'WKB'
+            The GeoArrow encoding to use for the data conversion.
+        interleaved : bool, default True
+            Only relevant for 'geoarrow' encoding. If True, the geometries'
+            coordinates are interleaved in a single fixed size list array.
+            If False, the coordinates are stored as separate arrays in a
+            struct type.
+        include_z : bool, default None
+            Only relevant for 'geoarrow' encoding (for WKB, the dimensionality
+            of the individual geometries is preserved).
+            If False, return 2D geometries. If True, include the third dimension
+            in the output (if a geometry has no third dimension, the z-coordinates
+            will be NaN). By default, will infer the dimensionality from the
+            input geometries. Note that this inference can be unreliable with
+            empty geometries (for a guaranteed result, it is recommended to
+            specify the keyword).
+
+        Returns
+        -------
+        GeoArrowArray
+            A generic Arrow array object with geometry data encoded to GeoArrow.
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Point
+        >>> gser = GeoSeries([Point(1, 2), Point(2, 1)])
+        >>> gser
+        0    POINT (1 2)
+        1    POINT (2 1)
+        dtype: geometry
+
+        >>> arrow_array = gser.to_arrow()
+        >>> arrow_array
+        <geopandas.io._geoarrow.GeoArrowArray object at ...>
+
+        The returned array object needs to be consumed by a library implementing
+        the Arrow PyCapsule Protocol. For example, wrapping the data as a
+        pyarrow.Array (requires pyarrow >= 14.0):
+
+        >>> import pyarrow as pa
+        >>> array = pa.array(arrow_array)
+        >>> array
+        <pyarrow.lib.BinaryArray object at ...>
+        [
+          0101000000000000000000F03F0000000000000040,
+          01010000000000000000000040000000000000F03F
+        ]
+
+        """
+        # Because this function returns the arrow array in memory, we simply rely on geopandas's implementation.
+        # This also returns a geopandas specific data type, which can be converted to an actual pyarrow array,
+        # so there is no direct Sedona equivalent. This way we also get all of the arguments implemented for free.
+        return self.to_geopandas().to_arrow(
+            geometry_encoding=geometry_encoding,
+            interleaved=interleaved,
+            include_z=include_z,
+        )
 
     def clip(self, mask, keep_geom_type: bool = False, sort=False) -> "GeoSeries":
         raise NotImplementedError(
@@ -4348,6 +4524,15 @@ class GeoSeries(GeoFrame, pspd.Series):
                 return pspd.Series(lst), True
         else:
             return value, False
+
+    def _to_geoframe(self, name=None):
+        if name is not None:
+            renamed = self.rename(name)
+        elif self._column_label is None:
+            renamed = self.rename("geometry")
+        else:
+            renamed = self
+        return GeoDataFrame(pspd.DataFrame(renamed._internal))
 
 
 # -----------------------------------------------------------------------------

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -1131,6 +1131,232 @@ class GeoSeries(GeoFrame, pspd.Series):
             )
         )
 
+    def dwithin(self, other, distance, align=None):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is within a set distance from ``other``.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test for
+            equality.
+        distance : float, np.array, pd.Series
+            Distance(s) to test if each geometry is within. A scalar distance will be
+            applied to all geometries. An array or Series will be applied elementwise.
+            If np.array or pd.Series are used then it must have same length as the
+            GeoSeries.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices.
+            If False, the order of elements is preserved. None defaults to True.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(0, 4),
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(1, 0), (4, 2), (2, 2)]),
+        ...         Polygon([(2, 0), (3, 2), (2, 2)]),
+        ...         LineString([(2, 0), (2, 2)]),
+        ...         Point(1, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1             LINESTRING (0 0, 0 2)
+        2             LINESTRING (0 0, 0 1)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((1 0, 4 2, 2 2, 1 0))
+        2    POLYGON ((2 0, 3 2, 2 2, 2 0))
+        3             LINESTRING (2 0, 2 2)
+        4                       POINT (1 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries contains a single
+        geometry:
+
+        >>> point = Point(0, 1)
+        >>> s2.dwithin(point, 1.8)
+        1     True
+        2    False
+        3    False
+        4     True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.dwithin(s2, distance=1, align=True)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.dwithin(s2, distance=1, align=False)
+        0     True
+        1    False
+        2    False
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is within the set distance of *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.within
+        """
+
+        if not isinstance(distance, (float, int)):
+            raise NotImplementedError(
+                "Array-like distance for dwithin not implemented yet."
+            )
+
+        return self._row_wise_operation(
+            f"ST_DWithin(`L`, `R`, {distance})",
+            other,
+            align,
+            rename="dwithin",
+            returns_geom=False,
+            default_val="FALSE",
+        )
+
+    def difference(self, other, align=None) -> "GeoSeries":
+        """Returns a ``GeoSeries`` of the points in each aligned geometry that
+        are not in `other`.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Unlike Geopandas, Sedona does not support this operation for GeometryCollections.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            difference to.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        GeoSeries
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 6),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (1 0, 1 3)
+        3             LINESTRING (2 0, 0 2)
+        4                       POINT (1 1)
+        5                       POINT (0 1)
+        dtype: geometry
+
+        We can do difference of each geometry and a single
+        shapely geometry:
+
+        >>> s.difference(Polygon([(0, 0), (1, 1), (0, 1)]))
+        0       POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
+        1         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
+        2                       LINESTRING (1 1, 2 2)
+        3    MULTILINESTRING ((2 0, 1 1), (1 1, 0 2))
+        4                                 POINT EMPTY
+        dtype: geometry
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.difference(s2, align=True)
+        0                                        None
+        1         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
+        2    MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))
+        3                            LINESTRING EMPTY
+        4                                 POINT (0 1)
+        5                                        None
+        dtype: geometry
+
+        >>> s.difference(s2, align=False)
+        0         POLYGON ((0 2, 2 2, 1 1, 0 1, 0 2))
+        1    POLYGON ((0 0, 0 2, 1 2, 2 2, 1 1, 0 0))
+        2    MULTILINESTRING ((0 0, 1 1), (1 1, 2 2))
+        3                       LINESTRING (2 0, 0 2)
+        4                                 POINT EMPTY
+        dtype: geometry
+
+        See Also
+        --------
+        GeoSeries.symmetric_difference
+        GeoSeries.union
+        GeoSeries.intersection
+        """
+        return self._row_wise_operation(
+            "ST_Difference(`L`, `R`)",
+            other,
+            align,
+            rename="difference",
+            returns_geom=True,
+        )
+
     @property
     def is_simple(self) -> pspd.Series:
         """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
@@ -2698,14 +2924,22 @@ class GeoSeries(GeoFrame, pspd.Series):
             NATURAL_ORDER_COLUMN_NAME if align is False else SPARK_DEFAULT_INDEX_NAME
         )
 
-        if isinstance(other, BaseGeometry):
-            other = GeoSeries([other] * len(self))
-
-        # e.g int input
         if not isinstance(other, pspd.Series):
-            other = pspd.Series([other] * len(self))
+            # generator instead of a in-memory list
+            data = [other for _ in range(len(self))]
 
-        assert isinstance(other, pspd.Series), f"Invalid type for other: {type(other)}"
+            # e.g int, Geom, etc
+            other = (
+                GeoSeries(data)
+                if isinstance(other, BaseGeometry)
+                else pspd.Series(data)
+            )
+
+            # To make sure the result is the same length, we set natural column as the index
+            # in case the index is not the default range index from 0.
+            # Alternatively, we could create 'other' using the same index as self,
+            # but that would require index=self.index.to_pandas() which is less scalable.
+            index_col = NATURAL_ORDER_COLUMN_NAME
 
         # This code assumes there is only one index (SPARK_DEFAULT_INDEX_NAME)
         # and would need to be updated if Sedona later supports multi-index

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -1052,6 +1052,8 @@ class GeoSeries(GeoFrame, pspd.Series):
             index,
             align=False,
             rename="get_geometry",
+            returns_geom=True,
+            default_val=None,
         )
 
     @property
@@ -1395,6 +1397,129 @@ class GeoSeries(GeoFrame, pspd.Series):
         geom = ps_series.iloc[0]
         return geom
 
+    def crosses(self, other, align=None) -> pspd.Series:
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that cross `other`.
+
+        An object is said to cross `other` if its `interior` intersects the
+        `interior` of the other but does not contain it, and the dimension of
+        the intersection is less than the dimension of the one or the other.
+
+        Note: Unlike Geopandas, Sedona's implementation always return NULL when GeometryCollection is involved.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            crossed.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         LineString([(1, 0), (1, 3)]),
+        ...         LineString([(2, 0), (0, 2)]),
+        ...         Point(1, 1),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1             LINESTRING (0 0, 2 2)
+        2             LINESTRING (2 0, 0 2)
+        3                       POINT (0 1)
+        dtype: geometry
+        >>> s2
+        1    LINESTRING (1 0, 1 3)
+        2    LINESTRING (2 0, 0 2)
+        3              POINT (1 1)
+        4              POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries crosses a single
+        geometry:
+
+        >>> line = LineString([(-1, 1), (3, 1)])
+        >>> s.crosses(line)
+        0     True
+        1     True
+        2     True
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.crosses(s2, align=True)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.crosses(s2, align=False)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        Notice that a line does not cross a point that it contains.
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``crosses`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.disjoint
+        GeoSeries.intersects
+
+        """
+        # Sedona does not support GeometryCollection (errors), so we return NULL for now to avoid error
+        select = """
+        CASE
+            WHEN GeometryType(`L`) == 'GEOMETRYCOLLECTION' OR GeometryType(`R`) == 'GEOMETRYCOLLECTION' THEN NULL
+            ELSE ST_Crosses(`L`, `R`)
+        END
+        """
+
+        result = self._row_wise_operation(
+            select, other, align, rename="crosses", default_val="FALSE"
+        )
+        return to_bool(result)
+
+    def disjoint(self, other, align=None):
+        # Implementation of the abstract method
+        raise NotImplementedError("This method is not implemented yet.")
+
     def intersects(
         self, other: Union["GeoSeries", BaseGeometry], align: Union[bool, None] = None
     ) -> pspd.Series:
@@ -1500,21 +1625,667 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.intersection
         """
 
-        select = "ST_Intersects(`L`, `R`)"
+        result = self._row_wise_operation(
+            "ST_Intersects(`L`, `R`)",
+            other,
+            align,
+            rename="intersects",
+            default_val="FALSE",
+        )
+        return to_bool(result)
 
-        # ps.Series.fillna() call in to_bool, doesn't work for the output for
-        # intersects here for some reason. So we manually handle the nulls here.
-        select = f"""
-            CASE
-                WHEN `L` IS NULL OR `R` IS NULL THEN FALSE
-                ELSE {select}
-            END
+    def overlaps(self, other, align=None) -> pspd.Series:
+        """Returns True for all aligned geometries that overlap other, else False.
+
+        In the original Geopandas, Geometries overlap if they have more than one but not all
+        points in common, have the same dimension, and the intersection of the
+        interiors of the geometries has the same dimension as the geometries
+        themselves.
+
+        However, in Sedona, we return True in the case where the geometries points match.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if
+            overlaps.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         MultiPoint([(0, 0), (0, 1)]),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (0, 2)]),
+        ...         LineString([(0, 1), (1, 1)]),
+        ...         LineString([(1, 1), (3, 3)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+
+        We can check if each geometry of GeoSeries overlaps a single
+        geometry:
+
+        >>> polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        >>> s.overlaps(polygon)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We align both GeoSeries
+        based on index values and compare elements with the same index.
+
+        >>> s.overlaps(s2)
+        0    False
+        1     True
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.overlaps(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3    False
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``overlaps`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.crosses
+        GeoSeries.intersects
+
+        """
+        # Note: We cannot efficiently match geopandas behavior because Sedona's ST_Overlaps returns True for equal geometries
+        # ST_Overlaps(`L`, `R`) AND ST_Equals(`L`, `R`) does not work because ST_Equals errors on invalid geometries
+
+        result = self._row_wise_operation(
+            "ST_Overlaps(`L`, `R`)",
+            other,
+            align,
+            rename="overlaps",
+            default_val="FALSE",
+        )
+        return to_bool(result)
+
+    def touches(self, other, align=None) -> pspd.Series:
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that touches `other`.
+
+        An object is said to touch `other` if it has at least one point in
+        common with `other` and its interior does not intersect with any part
+        of the other. Overlapping features therefore do not touch.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            touched.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, MultiPoint, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         MultiPoint([(0, 0), (0, 1)]),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (-2, 0), (0, -2)]),
+        ...         LineString([(0, 1), (1, 1)]),
+        ...         LineString([(1, 1), (3, 0)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 2 2)
+        3         MULTIPOINT ((0 0), (0 1))
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, -2 0, 0 -2, 0 0))
+        2               LINESTRING (0 1, 1 1)
+        3               LINESTRING (1 1, 3 0)
+        4                         POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries touches a single
+        geometry:
+
+        >>> line = LineString([(0, 0), (-1, -2)])
+        >>> s.touches(line)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.touches(s2, align=True)
+        0    False
+        1     True
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.touches(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3    False
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``touches`` *any* element of the other one.
+
+        See also
+        --------
+        GeoSeries.overlaps
+        GeoSeries.intersects
+
         """
 
         result = self._row_wise_operation(
-            select, other, align, rename="intersects", returns_geom=False
+            "ST_Touches(`L`, `R`)",
+            other,
+            align,
+            rename="touches",
+            default_val="FALSE",
         )
         return to_bool(result)
+
+    def within(self, other, align=None) -> pspd.Series:
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is within `other`.
+
+        An object is said to be within `other` if at least one of its points is located
+        in the `interior` and no points are located in the `exterior` of the other.
+        If either object is empty, this operation returns ``False``.
+
+        This is the inverse of `contains` in the sense that the
+        expression ``a.within(b) == b.contains(a)`` always evaluates to
+        ``True``.
+
+        Note: Sedona's behavior may also differ from Geopandas for GeometryCollections and for geometries that are equal.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if each
+            geometry is within.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        1    POLYGON ((0 0, 1 2, 0 2, 0 0))
+        2             LINESTRING (0 0, 0 2)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        2             LINESTRING (0 0, 0 2)
+        3             LINESTRING (0 0, 0 1)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries is within a single
+        geometry:
+
+        >>> polygon = Polygon([(0, 0), (2, 2), (0, 2)])
+        >>> s.within(polygon)
+        0     True
+        1     True
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s2.within(s)
+        0    False
+        1    False
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s2.within(s, align=False)
+        1     True
+        2    False
+        3     True
+        4     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is ``within`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.contains
+        """
+        result = self._row_wise_operation(
+            "ST_Within(`L`, `R`)",
+            other,
+            align,
+            rename="within",
+            default_val="FALSE",
+        )
+        return to_bool(result)
+
+    def covers(self, other, align=None) -> pspd.Series:
+        """
+        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is entirely covering `other`.
+
+        An object A is said to cover another object B if no points of B lie
+        in the exterior of A.
+        If either object is empty, this operation returns ``False``.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+        Sedona's behavior may also differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        See
+        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+        for reference.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to check is being covered.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         LineString([(1, 1), (1.5, 1.5)]),
+        ...         Point(0, 0),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        1         POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2                  LINESTRING (0 0, 2 2)
+        3                            POINT (0 0)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        2                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        3                            LINESTRING (1 1, 1.5 1.5)
+        4                                          POINT (0 0)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries covers a single
+        geometry:
+
+        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        >>> s.covers(poly)
+        0     True
+        1    False
+        2    False
+        3    False
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.covers(s2, align=True)
+        0    False
+        1    False
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        >>> s.covers(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``covers`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.covered_by
+        GeoSeries.overlaps
+        """
+        result = self._row_wise_operation(
+            "ST_Covers(`L`, `R`)",
+            other,
+            align,
+            rename="covers",
+            default_val="FALSE",
+        )
+        return to_bool(result)
+
+    def covered_by(self, other, align=None) -> pspd.Series:
+        """
+        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that is entirely covered by `other`.
+
+        An object A is said to cover another object B if no points of B lie
+        in the exterior of A.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+        Sedona's behavior may differ from Geopandas for GeometryCollections.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        See
+        https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
+        for reference.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to check is being covered.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         LineString([(1, 1), (1.5, 1.5)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         LineString([(0, 0), (2, 2)]),
+        ...         Point(0, 0),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        1                  POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        2                            LINESTRING (1 1, 1.5 1.5)
+        3                                          POINT (0 0)
+        dtype: geometry
+        >>>
+
+        >>> s2
+        1    POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))
+        2         POLYGON ((0 0, 2 2, 0 2, 0 0))
+        3                  LINESTRING (0 0, 2 2)
+        4                            POINT (0 0)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries is covered by a single
+        geometry:
+
+        >>> poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        >>> s.covered_by(poly)
+        0    True
+        1    True
+        2    True
+        3    True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s.covered_by(s2, align=True)
+        0    False
+        1     True
+        2     True
+        3     True
+        4    False
+        dtype: bool
+
+        >>> s.covered_by(s2, align=False)
+        0     True
+        1    False
+        2     True
+        3     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries is ``covered_by`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.covers
+        GeoSeries.overlaps
+        """
+        result = self._row_wise_operation(
+            "ST_CoveredBy(`L`, `R`)",
+            other,
+            align,
+            rename="covered_by",
+            default_val="FALSE",
+        )
+        return to_bool(result)
+
+    def distance(self, other, align=None) -> pspd.Series:
+        """Returns a ``Series`` containing the distance to aligned `other`.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            distance to.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (float)
+
+        Examples
+        --------
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 0), (1, 1)]),
+        ...         Polygon([(0, 0), (-1, 0), (-1, 1)]),
+        ...         LineString([(1, 1), (0, 0)]),
+        ...         Point(0, 0),
+        ...     ],
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+        ...         Point(3, 1),
+        ...         LineString([(1, 0), (2, 0)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0      POLYGON ((0 0, 1 0, 1 1, 0 0))
+        1    POLYGON ((0 0, -1 0, -1 1, 0 0))
+        2               LINESTRING (1 1, 0 0)
+        3                         POINT (0 0)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, ...
+        2                                          POINT (3 1)
+        3                                LINESTRING (1 0, 2 0)
+        4                                          POINT (0 1)
+        dtype: geometry
+
+        We can check the distance of each geometry of GeoSeries to a single
+        geometry:
+
+        >>> point = Point(-1, 0)
+        >>> s.distance(point)
+        0    1.0
+        1    0.0
+        2    1.0
+        3    1.0
+        dtype: float64
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and use elements with the same index using
+        ``align=True`` or ignore index and use elements based on their matching
+        order using ``align=False``:
+
+        >>> s.distance(s2, align=True)
+        0         NaN
+        1    0.707107
+        2    2.000000
+        3    1.000000
+        4         NaN
+        dtype: float64
+
+        >>> s.distance(s2, align=False)
+        0    0.000000
+        1    3.162278
+        2    0.707107
+        3    1.000000
+        dtype: float64
+        """
+
+        result = self._row_wise_operation(
+            "ST_Distance(`L`, `R`)", other, align, rename="distance", default_val="NULL"
+        )
+        return result
 
     def intersection(
         self, other: Union["GeoSeries", BaseGeometry], align: Union[bool, None] = None
@@ -1619,7 +2390,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.union
         """
         return self._row_wise_operation(
-            "ST_Intersection(`L`, `R`)", other, align, rename="intersection"
+            "ST_Intersection(`L`, `R`)",
+            other,
+            align,
+            rename="intersection",
+            returns_geom=True,
+            default_val="NULL",
         )
 
     def _row_wise_operation(
@@ -1628,11 +2404,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         other: Any,
         align: Union[bool, None],
         rename: str,
-        returns_geom: bool = True,
+        returns_geom: bool = False,
+        default_val: Union[str, None] = None,
     ):
         """
         Helper function to perform a row-wise operation on two GeoSeries.
         The self column and other column are aliased to `L` and `R`, respectively.
+
+        default_val : str or None (default "FALSE")
+            The value to use if either L or R is null. If None, nulls are not handled.
         """
         from pyspark.sql.functions import col
 
@@ -1666,6 +2446,17 @@ class GeoSeries(GeoFrame, pspd.Series):
             col(index_col),
         )
         joined_df = df.join(other_df, on=index_col, how="outer")
+
+        if default_val is not None:
+            # ps.Series.fillna() doesn't always work for the output for some reason
+            # so we manually handle the nulls here.
+            select = f"""
+                CASE
+                    WHEN `L` IS NULL OR `R` IS NULL THEN {default_val}
+                    ELSE {select}
+                END
+            """
+
         return self._query_geometry_column(
             select,
             cols=["L", "R"],
@@ -1678,9 +2469,124 @@ class GeoSeries(GeoFrame, pspd.Series):
         # Implementation of the abstract method
         raise NotImplementedError("This method is not implemented yet.")
 
-    def contains(self, other, align=None):
-        # Implementation of the abstract method
-        raise NotImplementedError("This method is not implemented yet.")
+    def contains(self, other, align=None) -> pspd.Series:
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each aligned geometry that contains `other`.
+
+        An object is said to contain `other` if at least one point of `other` lies in
+        the interior and no points of `other` lie in the exterior of the object.
+        (Therefore, any given polygon does not contain its own boundary - there is not
+        any point that lies in the interior.)
+        If either object is empty, this operation returns ``False``.
+
+        This is the inverse of `within` in the sense that the expression
+        ``a.contains(b) == b.within(a)`` always evaluates to ``True``.
+
+        Note: Sedona's implementation instead returns False for identical geometries.
+
+        The operation works on a 1-to-1 row-wise manner.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if it
+            is contained.
+        align : bool | None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+
+        Returns
+        -------
+        Series (bool)
+
+        Examples
+        --------
+
+        >>> from sedona.geopandas import GeoSeries
+        >>> from shapely.geometry import Polygon, LineString, Point
+        >>> s = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (1, 1), (0, 1)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         LineString([(0, 0), (0, 1)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(0, 4),
+        ... )
+        >>> s2 = GeoSeries(
+        ...     [
+        ...         Polygon([(0, 0), (2, 2), (0, 2)]),
+        ...         Polygon([(0, 0), (1, 2), (0, 2)]),
+        ...         LineString([(0, 0), (0, 2)]),
+        ...         Point(0, 1),
+        ...     ],
+        ...     index=range(1, 5),
+        ... )
+
+        >>> s
+        0    POLYGON ((0 0, 1 1, 0 1, 0 0))
+        1             LINESTRING (0 0, 0 2)
+        2             LINESTRING (0 0, 0 1)
+        3                       POINT (0 1)
+        dtype: geometry
+
+        >>> s2
+        1    POLYGON ((0 0, 2 2, 0 2, 0 0))
+        2    POLYGON ((0 0, 1 2, 0 2, 0 0))
+        3             LINESTRING (0 0, 0 2)
+        4                       POINT (0 1)
+        dtype: geometry
+
+        We can check if each geometry of GeoSeries contains a single
+        geometry:
+
+        >>> point = Point(0, 1)
+        >>> s.contains(point)
+        0    False
+        1     True
+        2    False
+        3     True
+        dtype: bool
+
+        We can also check two GeoSeries against each other, row by row.
+        The GeoSeries above have different indices. We can either align both GeoSeries
+        based on index values and compare elements with the same index using
+        ``align=True`` or ignore index and compare elements based on their matching
+        order using ``align=False``:
+
+        >>> s2.contains(s, align=True)
+        0    False
+        1    False
+        2    False
+        3     True
+        4    False
+        dtype: bool
+
+        >>> s2.contains(s, align=False)
+        1     True
+        2    False
+        3     True
+        4     True
+        dtype: bool
+
+        Notes
+        -----
+        This method works in a row-wise manner. It does not check if an element
+        of one GeoSeries ``contains`` any element of the other one.
+
+        See also
+        --------
+        GeoSeries.contains_properly
+        GeoSeries.within
+        """
+        result = self._row_wise_operation(
+            "ST_Contains(`L`, `R`)",
+            other,
+            align,
+            rename="contains",
+            default_val="FALSE",
+        )
+        return to_bool(result)
 
     def contains_properly(self, other, align=None):
         # Implementation of the abstract method
@@ -2398,16 +3304,21 @@ class GeoSeries(GeoFrame, pspd.Series):
             result = self._query_geometry_column(select, col, "")
         elif isinstance(value, (GeoSeries, GeometryArray, gpd.GeoSeries)):
 
-            if isinstance(value, (gpd.GeoSeries, GeometryArray)):
+            if not isinstance(value, GeoSeries):
                 value = GeoSeries(value)
 
-            # Replace all None's with empty geometries
+            # Replace all None's with empty geometries (this is a recursive call)
             value = value.fillna(None)
 
             # Coalesce: If the value in L is null, use the corresponding value in R for that row
             select = f"COALESCE(`L`, `R`)"
             result = self._row_wise_operation(
-                select, value, align=None, rename="fillna"
+                select,
+                value,
+                align=None,
+                rename="fillna",
+                returns_geom=True,
+                default_val=None,
             )
         else:
             raise ValueError(f"Invalid value type: {type(value)}")

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -28,7 +28,8 @@ from pyspark.pandas.frame import DataFrame as PandasOnSparkDataFrame
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.series import first_series
 from pyspark.pandas.utils import scol_for, log_advice
-from pyspark.sql.types import BinaryType
+from pyspark.sql.types import BinaryType, NullType
+from sedona.spark.sql.types import GeometryType
 
 import shapely
 from shapely.geometry.base import BaseGeometry
@@ -378,28 +379,6 @@ class GeoSeries(GeoFrame, pspd.Series):
         self._anchor: GeoDataFrame
         self._col_label: Label
 
-        use_same_anchor = True
-
-        def try_geom_to_ewkb(x) -> bytes:
-            nonlocal use_same_anchor
-            if isinstance(x, BaseGeometry):
-                kwargs = {}
-                if crs:
-                    from pyproj import CRS
-
-                    srid = CRS.from_user_input(crs)
-                    kwargs["srid"] = srid.to_epsg()
-                use_same_anchor = False
-
-                return shapely.wkb.dumps(x, **kwargs)
-            elif isinstance(x, bytearray):
-                use_same_anchor = False
-                return bytes(x)
-            elif x is None or isinstance(x, bytes):
-                return x
-            else:
-                raise TypeError(f"expected geometry or bytes, got {type(x)}: {x}")
-
         if isinstance(
             data, (GeoDataFrame, GeoSeries, PandasOnSparkSeries, PandasOnSparkDataFrame)
         ):
@@ -418,29 +397,21 @@ class GeoSeries(GeoFrame, pspd.Series):
                     "allow_override=True)' to overwrite CRS or "
                     "'GeoSeries.to_crs(crs)' to reproject geometries. "
                 )
-            # This is a temporary workaround since pyspark errors when creating a ps.Series from a ps.Series
-            # This is NOT a scalable solution since we call to_pandas() on the data and is a hacky solution
-            # but this should be resolved if/once https://github.com/apache/spark/pull/51300 is merged in.
-            # For now, we reset self._anchor = data to have keep the geometry information (e.g crs) that's lost in to_pandas()
 
-            pd_data = data.to_pandas()
+            # PySpark Pandas' ps.Series.__init__() does not construction from a
+            # ps.Series input. For now, we manually implement the logic.
 
-            try:
-                pd_data = pd_data.apply(try_geom_to_ewkb)
-            except Exception as e:
-                raise TypeError(f"Non-geometry column passed to GeoSeries: {e}")
+            index = data._col_label if index is None else index
+            ps_df = pspd.DataFrame(data._anchor)
 
             super().__init__(
-                data=pd_data,
+                data=ps_df,
                 index=index,
                 dtype=dtype,
                 name=name,
                 copy=copy,
                 fastpath=fastpath,
             )
-
-            if use_same_anchor:
-                self._anchor = data
         else:
             if isinstance(data, pd.Series):
                 assert index is None
@@ -448,9 +419,9 @@ class GeoSeries(GeoFrame, pspd.Series):
                 assert name is None
                 assert not copy
                 assert not fastpath
-                s = data
+                pd_series = data
             else:
-                s = pd.Series(
+                pd_series = pd.Series(
                     data=data,
                     index=index,
                     dtype=dtype,
@@ -459,21 +430,24 @@ class GeoSeries(GeoFrame, pspd.Series):
                     fastpath=fastpath,
                 )
 
-            try:
-                pd_series = s.apply(try_geom_to_ewkb)
-            except Exception as e:
-                raise TypeError(f"Non-geometry column passed to GeoSeries: {e}")
-
             # initialize the parent class pyspark Series with the pandas Series
             super().__init__(data=pd_series)
 
-        # manually set it to binary type
+        # Ensure we're storing geometry types
         col = next(
             field.name
             for field in self._internal.spark_frame.schema.fields
             if field.name not in (NATURAL_ORDER_COLUMN_NAME, SPARK_DEFAULT_INDEX_NAME)
         )
-        self._internal.spark_frame.schema[col].dataType = BinaryType()
+        datatype = self._internal.spark_frame.schema[col].dataType
+        # Empty lists input will lead to NullType(), so we convert to GeometryType()
+        if datatype == NullType():
+            self._internal.spark_frame.schema[col].dataType = GeometryType()
+        elif datatype != GeometryType():
+            raise TypeError(
+                "Non geometry data passed to GeoSeries constructor, "
+                f"received data of dtype '{datatype.typeName()}'"
+            )
 
         if crs:
             self.set_crs(crs, inplace=True)
@@ -522,6 +496,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         tmp = self._process_geometry_column("ST_SRID", rename="crs", returns_geom=False)
         ps_series = tmp.take([0])
         srid = ps_series.iloc[0]
+
         # Sedona returns 0 if doesn't exist
         return CRS.from_user_input(srid) if srid != 0 and not pd.isna(srid) else None
 
@@ -774,10 +749,6 @@ class GeoSeries(GeoFrame, pspd.Series):
             # must have rename for multiple columns since we don't know which name to default to
             assert rename
 
-        # Convert back to EWKB format if the return type is a geometry
-        if returns_geom:
-            query = f"ST_AsEWKB({query})"
-
         query = f"{query} as `{rename}`"
 
         exprs = [query]
@@ -831,20 +802,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         Same as `to_geopandas()`, without issuing the advice log for internal usage.
         """
         pd_series = self._to_internal_pandas()
-        try:
-            return gpd.GeoSeries(
-                pd_series.map(
-                    lambda wkb: (
-                        shapely.wkb.loads(bytes(wkb)) if not pd.isna(wkb) else None
-                    )
-                ),
-                crs=self.crs,
-            )
-        except TypeError:
-            return gpd.GeoSeries(pd_series, crs=self.crs)
+        return gpd.GeoSeries(pd_series, crs=self.crs)
 
     def to_spark_pandas(self) -> pspd.Series:
-        return pspd.Series(self._psdf._to_internal_pandas())
+        return pspd.Series(pspd.DataFrame(self._psdf._internal))
 
     # ============================================================================
     # PROPERTIES AND ATTRIBUTES
@@ -3408,7 +3369,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         if isinstance(data, list) and not isinstance(data[0], (tuple, list)):
             data = [(obj,) for obj in data]
 
-        select = f"ST_AsEWKB({select}) as geometry"
+        select = f"{select} as geometry"
 
         if isinstance(data, pspd.Series):
             spark_df = data._internal.spark_frame

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -31,6 +31,14 @@ from pyspark.pandas.utils import scol_for, log_advice
 from pyspark.sql.types import BinaryType, NullType
 from sedona.spark.sql.types import GeometryType
 
+from sedona.spark.sql import st_aggregates as sta
+from sedona.spark.sql import st_constructors as stc
+from sedona.spark.sql import st_functions as stf
+from sedona.spark.sql import st_predicates as stp
+
+from pyspark.sql import Column as PySparkColumn
+from pyspark.sql import functions as F
+
 import shapely
 from shapely.geometry.base import BaseGeometry
 
@@ -42,6 +50,7 @@ from sedona.geopandas.sindex import SpatialIndex
 from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,  # __index_level_0__
     NATURAL_ORDER_COLUMN_NAME,
+    SPARK_DEFAULT_SERIES_NAME,  # '0'
 )
 
 
@@ -434,19 +443,13 @@ class GeoSeries(GeoFrame, pspd.Series):
             super().__init__(data=pd_series)
 
         # Ensure we're storing geometry types
-        col = next(
-            field.name
-            for field in self._internal.spark_frame.schema.fields
-            if field.name not in (NATURAL_ORDER_COLUMN_NAME, SPARK_DEFAULT_INDEX_NAME)
-        )
-        datatype = self._internal.spark_frame.schema[col].dataType
-        # Empty lists input will lead to NullType(), so we convert to GeometryType()
-        if datatype == NullType():
-            self._internal.spark_frame.schema[col].dataType = GeometryType()
-        elif datatype != GeometryType():
+        if (
+            self.spark.data_type != GeometryType()
+            and self.spark.data_type != NullType()
+        ):
             raise TypeError(
                 "Non geometry data passed to GeoSeries constructor, "
-                f"received data of dtype '{datatype.typeName()}'"
+                f"received data of dtype '{self.spark.data_type.typeName()}'"
             )
 
         if crs:
@@ -493,8 +496,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         if len(self) == 0:
             return None
 
-        tmp_series: pspd.Series = self._process_geometry_column(
-            "ST_SRID", rename="crs", returns_geom=False
+        spark_col = stf.ST_SRID(self.spark.column)
+        tmp_series = self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
         )
 
         # All geometries should have the same srid
@@ -629,15 +634,12 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         # 0 indicates no srid in sedona
         new_epsg = crs.to_epsg() if crs else 0
-        col = self.get_first_geometry_column()
 
-        select = f"ST_SetSRID(`{col}`, {new_epsg})"
-
-        # Keep the same column name instead of renaming it
-        result = self._query_geometry_column(select, col, rename="")
+        spark_col = stf.ST_SetSRID(self.spark.column, new_epsg)
+        result = self._query_geometry_column(spark_col)
 
         if inplace:
-            self._update_anchor(_to_spark_pandas_df(result))
+            self._update_inplace(result)
             return None
 
         return result
@@ -646,63 +648,9 @@ class GeoSeries(GeoFrame, pspd.Series):
     # INTERNAL HELPER METHODS
     # ============================================================================
 
-    def _process_geometry_column(
-        self,
-        operation: str,
-        rename: str,
-        returns_geom: bool = True,
-        is_aggr: bool = False,
-        *args,
-        **kwargs,
-    ) -> Union["GeoSeries", pspd.Series]:
-        """
-        Helper method to process a single geometry column with a specified operation.
-        This method wraps the _query_geometry_column method for simpler convenient use.
-
-        Parameters
-        ----------
-        operation : str
-            The spatial operation to apply (e.g., 'ST_Area', 'ST_Buffer').
-        rename : str
-            The name of the resulting column. If empty, the old column name is maintained.
-        args : tuple
-            Positional arguments for the operation.
-        kwargs : dict
-            Keyword arguments for the operation.
-
-        Returns
-        -------
-        GeoSeries
-            A GeoSeries with the operation applied to the geometry column.
-        """
-        # Find the first column with BinaryType or GeometryType
-        first_col = self.get_first_geometry_column()  # TODO: fixme
-
-        # Handle both positional and keyword arguments
-        all_args = list(args)
-        for k, v in kwargs.items():
-            all_args.append(v)
-
-        # Join all arguments as comma-separated values
-        params = ""
-        if all_args:
-            params_list = [
-                str(arg) if isinstance(arg, (int, float)) else repr(arg)
-                for arg in all_args
-            ]
-            params = f", {', '.join(params_list)}"
-
-        sql_expr = f"{operation}(`{first_col}`{params})"
-
-        return self._query_geometry_column(
-            sql_expr, first_col, rename, returns_geom=returns_geom, is_aggr=is_aggr
-        )
-
     def _query_geometry_column(
         self,
-        query: str,
-        cols: Union[List[str], str],
-        rename: str,
+        spark_col: PySparkColumn,
         df: pyspark.sql.DataFrame = None,
         returns_geom: bool = True,
         is_aggr: bool = False,
@@ -712,12 +660,8 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         Parameters
         ----------
-        query : str
+        spark_col : str
             The query to apply to the geometry column.
-        cols : List[str] or str
-            The names of the columns to query.
-        rename : str
-            The name of the resulting column.
         df : pyspark.sql.DataFrame
             The dataframe to query. If not provided, the internal dataframe will be used.
         returns_geom : bool, default True
@@ -730,46 +674,29 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries
             A GeoSeries with the operation applied to the geometry column.
         """
-        if not cols:
-            raise ValueError("No valid geometry column found.")
 
         df = self._internal.spark_frame if df is None else df
 
-        if isinstance(cols, str):
-            col = cols
-            data_type = df.schema[col].dataType
-            if isinstance(data_type, BinaryType):
-                query = query.replace(f"`{cols}`", f"ST_GeomFromWKB(`{cols}`)")
+        rename = self.name if self.name else SPARK_DEFAULT_SERIES_NAME
 
-            rename = col if not rename else rename
+        col_expr = spark_col.alias(rename)
 
-        elif isinstance(cols, list):
-            for col in cols:
-                data_type = df.schema[col].dataType
-
-                if isinstance(data_type, BinaryType):
-                    # the backticks here are important so we don't match strings that happen to be the same as the column name
-                    query = query.replace(f"`{col}`", f"ST_GeomFromWKB(`{col}`)")
-
-            # must have rename for multiple columns since we don't know which name to default to
-            assert rename
-
-        query = f"{query} as `{rename}`"
-
-        exprs = [query]
+        exprs = [col_expr]
 
         index_spark_columns = []
         index_fields = []
         if not is_aggr:
             # We always select NATURAL_ORDER_COLUMN_NAME, to avoid having to regenerate it in the result
             # We always select SPARK_DEFAULT_INDEX_NAME, to retain series index info
-            exprs.append(SPARK_DEFAULT_INDEX_NAME)
-            exprs.append(NATURAL_ORDER_COLUMN_NAME)
+
+            exprs.append(scol_for(df, SPARK_DEFAULT_INDEX_NAME))
+            exprs.append(scol_for(df, NATURAL_ORDER_COLUMN_NAME))
+
             index_spark_columns = [scol_for(df, SPARK_DEFAULT_INDEX_NAME)]
             index_fields = [self._internal.index_fields[0]]
         # else if is_aggr, we don't select the index columns
 
-        sdf = df.selectExpr(*exprs)
+        sdf = df.select(*exprs)
 
         internal = self._internal.copy(
             spark_frame=sdf,
@@ -781,7 +708,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         )
         ps_series = first_series(PandasOnSparkDataFrame(internal))
 
-        return GeoSeries(ps_series) if returns_geom else ps_series
+        # Convert spark series default name to pandas series default name (None) if needed
+        series_name = None if rename == SPARK_DEFAULT_SERIES_NAME else rename
+        ps_series = ps_series.rename(series_name)
+
+        result = GeoSeries(ps_series) if returns_geom else ps_series
+        return result
 
     # ============================================================================
     # CONVERSION AND SERIALIZATION METHODS
@@ -841,7 +773,7 @@ class GeoSeries(GeoFrame, pspd.Series):
         >>> index.size
         2
         """
-        geometry_column = self.get_first_geometry_column()
+        geometry_column = _get_series_col_name(self)
         if geometry_column is None:
             raise ValueError("No geometry column found in GeoSeries")
         return SpatialIndex(self._internal.spark_frame, column_name=geometry_column)
@@ -896,8 +828,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         1    4.0
         dtype: float64
         """
-        return self._process_geometry_column(
-            "ST_Area", rename="area", returns_geom=False
+
+        spark_col = stf.ST_Area(self.spark.column)
+
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
         )
 
     @property
@@ -923,8 +859,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         1    POINT
         dtype: object
         """
-        result = self._process_geometry_column(
-            "GeometryType", rename="geom_type", returns_geom=False
+        spark_col = stf.GeometryType(self.spark.column)
+        result = self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
         )
 
         # Sedona returns the string in all caps unlike Geopandas
@@ -974,16 +912,30 @@ class GeoSeries(GeoFrame, pspd.Series):
         3    4.828427
         dtype: float64
         """
-        col = self.get_first_geometry_column()
-        select = f"""
-            CASE
-                WHEN GeometryType(`{col}`) IN ('LINESTRING', 'MULTILINESTRING') THEN ST_Length(`{col}`)
-                WHEN GeometryType(`{col}`) IN ('POLYGON', 'MULTIPOLYGON') THEN ST_Perimeter(`{col}`)
-                WHEN GeometryType(`{col}`) IN ('POINT', 'MULTIPOINT') THEN 0.0
-                WHEN GeometryType(`{col}`) IN ('GEOMETRYCOLLECTION') THEN ST_Length(`{col}`) + ST_Perimeter(`{col}`)
-            END"""
+
+        spark_expr = (
+            F.when(
+                stf.GeometryType(self.spark.column).isin(
+                    ["LINESTRING", "MULTILINESTRING"]
+                ),
+                stf.ST_Length(self.spark.column),
+            )
+            .when(
+                stf.GeometryType(self.spark.column).isin(["POLYGON", "MULTIPOLYGON"]),
+                stf.ST_Perimeter(self.spark.column),
+            )
+            .when(
+                stf.GeometryType(self.spark.column).isin(["POINT", "MULTIPOINT"]),
+                0.0,
+            )
+            .when(
+                stf.GeometryType(self.spark.column).isin(["GEOMETRYCOLLECTION"]),
+                stf.ST_Length(self.spark.column) + stf.ST_Perimeter(self.spark.column),
+            )
+        )
         return self._query_geometry_column(
-            select, col, rename="length", returns_geom=False
+            spark_expr,
+            returns_geom=False,
         )
 
     @property
@@ -1025,8 +977,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.is_valid_reason : reason for invalidity
         """
-        result = self._process_geometry_column(
-            "ST_IsValid", rename="is_valid", returns_geom=False
+
+        spark_col = stf.ST_IsValid(self.spark.column)
+        result = self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
         )
         return to_bool(result)
 
@@ -1071,8 +1026,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.is_valid : detect invalid geometries
         GeoSeries.make_valid : fix invalid geometries
         """
-        return self._process_geometry_column(
-            "ST_IsValidReason", rename="is_valid_reason", returns_geom=False
+        spark_col = stf.ST_IsValidReason(self.spark.column)
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
         )
 
     @property
@@ -1104,8 +1061,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.isna : detect missing values
         """
-        result = self._process_geometry_column(
-            "ST_IsEmpty", rename="is_empty", returns_geom=False
+        spark_expr = stf.ST_IsEmpty(self.spark.column)
+        result = self._query_geometry_column(
+            spark_expr,
+            returns_geom=False,
         )
         return to_bool(result)
 
@@ -1244,13 +1203,16 @@ class GeoSeries(GeoFrame, pspd.Series):
                 "Array-like distance for dwithin not implemented yet."
             )
 
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_DWithin(F.col("L"), F.col("R"), F.lit(distance))
         return self._row_wise_operation(
-            f"ST_DWithin(`L`, `R`, {distance})",
-            other,
-            align,
-            rename="dwithin",
+            spark_expr,
+            other_series,
+            align=align,
             returns_geom=False,
-            default_val="FALSE",
+            default_val=False,
         )
 
     def difference(self, other, align=None) -> "GeoSeries":
@@ -1354,11 +1316,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.union
         GeoSeries.intersection
         """
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stf.ST_Difference(F.col("L"), F.col("R"))
         return self._row_wise_operation(
-            "ST_Difference(`L`, `R`)",
-            other,
-            align,
-            rename="difference",
+            spark_expr,
+            other_series,
+            align=align,
             returns_geom=True,
         )
 
@@ -1389,8 +1355,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         1     True
         dtype: bool
         """
-        result = self._process_geometry_column(
-            "ST_IsSimple", rename="is_simple", returns_geom=False
+        spark_expr = stf.ST_IsSimple(self.spark.column)
+        result = self._query_geometry_column(
+            spark_expr,
+            returns_geom=False,
         )
         return to_bool(result)
 
@@ -1453,8 +1421,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         1     True
         dtype: bool
         """
-        return self._process_geometry_column(
-            "ST_HasZ", rename="has_z", returns_geom=False
+        spark_expr = stf.ST_HasZ(self.spark.column)
+        return self._query_geometry_column(
+            spark_expr,
+            returns_geom=False,
         )
 
     def get_precision(self):
@@ -1536,22 +1506,25 @@ class GeoSeries(GeoFrame, pspd.Series):
         """
 
         # Sedona errors on negative indexes, so we use a case statement to handle it ourselves
-        select = """
-        ST_GeometryN(
-            `L`,
-            CASE
-                WHEN ST_NumGeometries(`L`) + `R` < 0 THEN NULL
-                WHEN `R` < 0 THEN ST_NumGeometries(`L`) + `R`
-                ELSE `R`
-            END
+        spark_expr = stf.ST_GeometryN(
+            F.col("L"),
+            F.when(
+                stf.ST_NumGeometries(F.col("L")) + F.col("R") < 0,
+                None,
+            )
+            .when(F.col("R") < 0, stf.ST_NumGeometries(F.col("L")) + F.col("R"))
+            .otherwise(F.col("R")),
         )
-        """
+
+        other, _ = self._make_series_of_val(index)
+
+        # align = False either way
+        align = False
 
         return self._row_wise_operation(
-            select,
-            index,
-            align=False,
-            rename="get_geometry",
+            spark_expr,
+            other,
+            align=align,
             returns_geom=True,
             default_val=None,
         )
@@ -1590,15 +1563,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.exterior : outer boundary (without interior rings)
 
         """
-        col = self.get_first_geometry_column()
         # Geopandas and shapely return NULL for GeometryCollections, so we handle it separately
         # https://shapely.readthedocs.io/en/stable/reference/shapely.boundary.html
-        select = f"""
-            CASE
-                WHEN GeometryType(`{col}`) IN ('GEOMETRYCOLLECTION') THEN NULL
-                ELSE ST_Boundary(`{col}`)
-            END"""
-        return self._query_geometry_column(select, col, rename="boundary")
+        spark_expr = F.when(
+            stf.GeometryType(self.spark.column).isin(["GEOMETRYCOLLECTION"]),
+            None,
+        ).otherwise(stf.ST_Boundary(self.spark.column))
+        return self._query_geometry_column(
+            spark_expr,
+        )
 
     @property
     def centroid(self) -> "GeoSeries":
@@ -1635,7 +1608,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.representative_point : point guaranteed to be within each geometry
         """
-        return self._process_geometry_column("ST_Centroid", rename="centroid")
+        spark_expr = stf.ST_Centroid(self.spark.column)
+        return self._query_geometry_column(
+            spark_expr,
+            returns_geom=True,
+        )
 
     def concave_hull(self, ratio=0.0, allow_holes=False):
         # Implementation of the abstract method
@@ -1698,7 +1675,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.convex_hull : convex hull geometry
         """
-        return self._process_geometry_column("ST_Envelope", rename="envelope")
+        spark_expr = stf.ST_Envelope(self.spark.column)
+        return self._query_geometry_column(
+            spark_expr,
+            returns_geom=True,
+        )
 
     def minimum_rotated_rectangle(self):
         # Implementation of the abstract method
@@ -1815,9 +1796,11 @@ class GeoSeries(GeoFrame, pspd.Series):
                 "Sedona only supports the 'structure' method for make_valid"
             )
 
-        col = self.get_first_geometry_column()
-        select = f"ST_MakeValid(`{col}`, {keep_collapsed})"
-        return self._query_geometry_column(select, col, rename="make_valid")
+        spark_expr = stf.ST_MakeValid(self.spark.column, keep_collapsed)
+        return self._query_geometry_column(
+            spark_expr,
+            returns_geom=True,
+        )
 
     def reverse(self):
         # Implementation of the abstract method
@@ -1897,10 +1880,9 @@ class GeoSeries(GeoFrame, pspd.Series):
 
             return GeometryCollection()
 
-        # returns_geom needs to be False here so we don't convert back to EWKB format.
-        tmp = self._process_geometry_column(
-            "ST_Union_Aggr", rename="union_all", is_aggr=True, returns_geom=False
-        )
+        spark_expr = sta.ST_Union_Aggr(self.spark.column)
+        tmp = self._query_geometry_column(spark_expr, returns_geom=False, is_aggr=True)
+
         ps_series = tmp.take([0])
         geom = ps_series.iloc[0]
         return geom
@@ -2012,16 +1994,21 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         """
         # Sedona does not support GeometryCollection (errors), so we return NULL for now to avoid error
-        select = """
-        CASE
-            WHEN GeometryType(`L`) == 'GEOMETRYCOLLECTION' OR GeometryType(`R`) == 'GEOMETRYCOLLECTION' THEN NULL
-            ELSE ST_Crosses(`L`, `R`)
-        END
-        """
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
 
+        spark_expr = F.when(
+            (stf.GeometryType(F.col("L")) == "GEOMETRYCOLLECTION")
+            | (stf.GeometryType(F.col("R")) == "GEOMETRYCOLLECTION"),
+            None,
+        ).otherwise(stp.ST_Crosses(F.col("L"), F.col("R")))
         result = self._row_wise_operation(
-            select, other, align, rename="crosses", default_val="FALSE"
+            spark_expr,
+            other_series,
+            align,
+            default_val=False,
         )
+
         return to_bool(result)
 
     def disjoint(self, other, align=None):
@@ -2133,12 +2120,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.intersection
         """
 
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_Intersects(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Intersects(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="intersects",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2234,12 +2224,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         # Note: We cannot efficiently match geopandas behavior because Sedona's ST_Overlaps returns True for equal geometries
         # ST_Overlaps(`L`, `R`) AND ST_Equals(`L`, `R`) does not work because ST_Equals errors on invalid geometries
 
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_Overlaps(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Overlaps(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="overlaps",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2347,12 +2340,15 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         """
 
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_Touches(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Touches(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="touches",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2462,12 +2458,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.contains
         """
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_Within(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Within(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="within",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2578,12 +2578,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.covered_by
         GeoSeries.overlaps
         """
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_Covers(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Covers(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="covers",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2694,12 +2698,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.covers
         GeoSeries.overlaps
         """
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stp.ST_CoveredBy(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_CoveredBy(`L`, `R`)",
-            other,
+            spark_expr,
+            other_series,
             align,
-            rename="covered_by",
-            default_val="FALSE",
+            default_val=False,
         )
         return to_bool(result)
 
@@ -2790,8 +2798,15 @@ class GeoSeries(GeoFrame, pspd.Series):
         dtype: float64
         """
 
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stf.ST_Distance(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Distance(`L`, `R`)", other, align, rename="distance", default_val="NULL"
+            spark_expr,
+            other_series,
+            align,
+            default_val=None,
         )
         return result
 
@@ -2897,27 +2912,40 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.symmetric_difference
         GeoSeries.union
         """
-        return self._row_wise_operation(
-            "ST_Intersection(`L`, `R`)",
-            other,
+
+        other_series, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_expr = stf.ST_Intersection(F.col("L"), F.col("R"))
+        result = self._row_wise_operation(
+            spark_expr,
+            other_series,
             align,
-            rename="intersection",
             returns_geom=True,
-            default_val="NULL",
+            default_val=None,
         )
+        return result
 
     def _row_wise_operation(
         self,
-        select: str,
-        other: Any,
+        spark_col: PySparkColumn,
+        other: pspd.Series,
         align: Union[bool, None],
-        rename: str,
         returns_geom: bool = False,
-        default_val: Union[str, None] = None,
+        default_val: Any = None,
     ):
         """
         Helper function to perform a row-wise operation on two GeoSeries.
         The self column and other column are aliased to `L` and `R`, respectively.
+
+        align : bool or None (default None)
+            If True, automatically aligns GeoSeries based on their indices. None defaults to True.
+            If False, the order of elements is preserved.
+            Note: align should also be set to False when 'other' a geoseries created from a single object
+            (e.g. GeoSeries([Point(0, 0) * len(self)])), so that we align based on natural ordering in case
+            the index is not the default range index from 0.
+            Alternatively, we could create 'other' using the same index as self,
+            but that would require index=self.index.to_pandas() which is less scalable.
 
         default_val : str or None (default "FALSE")
             The value to use if either L or R is null. If None, nulls are not handled.
@@ -2929,27 +2957,11 @@ class GeoSeries(GeoFrame, pspd.Series):
             NATURAL_ORDER_COLUMN_NAME if align is False else SPARK_DEFAULT_INDEX_NAME
         )
 
-        if not isinstance(other, pspd.Series):
-            # generator instead of a in-memory list
-            data = [other for _ in range(len(self))]
-
-            # e.g int, Geom, etc
-            other = (
-                GeoSeries(data)
-                if isinstance(other, BaseGeometry)
-                else pspd.Series(data)
-            )
-
-            # To make sure the result is the same length, we set natural column as the index
-            # in case the index is not the default range index from 0.
-            # Alternatively, we could create 'other' using the same index as self,
-            # but that would require index=self.index.to_pandas() which is less scalable.
-            index_col = NATURAL_ORDER_COLUMN_NAME
-
         # This code assumes there is only one index (SPARK_DEFAULT_INDEX_NAME)
         # and would need to be updated if Sedona later supports multi-index
+
         df = self._internal.spark_frame.select(
-            col(self.get_first_geometry_column()).alias("L"),
+            self.spark.column.alias("L"),
             # For the left side:
             # - We always select NATURAL_ORDER_COLUMN_NAME, to avoid having to regenerate it in the result
             # - We always select SPARK_DEFAULT_INDEX_NAME, to retain series index info
@@ -2957,27 +2969,31 @@ class GeoSeries(GeoFrame, pspd.Series):
             col(SPARK_DEFAULT_INDEX_NAME),
         )
         other_df = other._internal.spark_frame.select(
-            col(_get_first_column_name(other)).alias("R"),
+            other.spark.column.alias("R"),
             # for the right side, we only need the column that we are joining on
             col(index_col),
         )
+
         joined_df = df.join(other_df, on=index_col, how="outer")
 
         if default_val is not None:
             # ps.Series.fillna() doesn't always work for the output for some reason
             # so we manually handle the nulls here.
-            select = f"""
+            spark_col = F.when(
+                F.col("L").isNull() | F.col("R").isNull(),
+                default_val,
+            ).otherwise(spark_col)
+            # The above is equivalent to the following:
+            f"""
                 CASE
                     WHEN `L` IS NULL OR `R` IS NULL THEN {default_val}
-                    ELSE {select}
+                    ELSE {spark_col}
                 END
             """
 
         return self._query_geometry_column(
-            select,
-            cols=["L", "R"],
-            rename=rename,
-            df=joined_df,
+            spark_col,
+            joined_df,
             returns_geom=returns_geom,
         )
 
@@ -3099,12 +3115,17 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.contains_properly
         GeoSeries.within
         """
+
+        other, extended = self._make_series_of_val(other)
+        align = False if extended else align
+
+        spark_col = stp.ST_Contains(F.col("L"), F.col("R"))
         result = self._row_wise_operation(
-            "ST_Contains(`L`, `R`)",
+            spark_col,
             other,
             align,
-            rename="contains",
-            default_val="FALSE",
+            returns_geom=False,
+            default_val=False,
         )
         return to_bool(result)
 
@@ -3150,8 +3171,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries
             A GeoSeries of buffered geometries.
         """
-        return self._process_geometry_column(
-            "ST_Buffer", rename="buffer", distance=distance
+        spark_col = stf.ST_Buffer(self.spark.column, distance)
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=True,
         )
 
     def to_parquet(self, path, **kwargs):
@@ -3164,16 +3187,8 @@ class GeoSeries(GeoFrame, pspd.Series):
         - kwargs: Any
             Additional arguments to pass to the Sedona DataFrame output function.
         """
-        col = self.get_first_geometry_column()
 
-        # Convert WKB to Sedona geometry objects
-        # Specify returns_geom=False to avoid turning it back into EWKB
-        result = self._query_geometry_column(
-            f"`{col}`",
-            cols=col,
-            rename="wkb",
-            returns_geom=False,
-        )
+        result = self._query_geometry_column(self.spark.column)
 
         # Use the Spark DataFrame's write method to write to GeoParquet format
         result._internal.spark_frame.write.format("geoparquet").save(path, **kwargs)
@@ -3256,7 +3271,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.z
 
         """
-        return self._process_geometry_column("ST_X", rename="x", returns_geom=False)
+        spark_col = stf.ST_X(self.spark.column)
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
+        )
 
     @property
     def y(self) -> pspd.Series:
@@ -3286,7 +3305,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.m
 
         """
-        return self._process_geometry_column("ST_Y", rename="y", returns_geom=False)
+        spark_col = stf.ST_Y(self.spark.column)
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
+        )
 
     @property
     def z(self) -> pspd.Series:
@@ -3316,7 +3339,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.m
 
         """
-        return self._process_geometry_column("ST_Z", rename="z", returns_geom=False)
+        spark_col = stf.ST_Z(self.spark.column)
+        return self._query_geometry_column(
+            spark_col,
+            returns_geom=False,
+        )
 
     @property
     def m(self) -> pspd.Series:
@@ -3614,7 +3641,7 @@ class GeoSeries(GeoFrame, pspd.Series):
             spark_df = data._internal.spark_frame
             assert len(schema) == 1
             spark_df = spark_df.withColumnRenamed(
-                _get_first_column_name(data), schema[0].name
+                _get_series_col_name(data), schema[0].name
             )
         else:
             spark_df = default_session().createDataFrame(data, schema=schema)
@@ -3685,10 +3712,10 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.notna : inverse of isna
         GeoSeries.is_empty : detect empty geometries
         """
-        col = self.get_first_geometry_column()
-        select = f"`{col}` IS NULL"
+        spark_expr = F.isnull(self.spark.column)
         result = self._query_geometry_column(
-            select, col, rename="isna", returns_geom=False
+            spark_expr,
+            returns_geom=False,
         )
         return to_bool(result)
 
@@ -3730,11 +3757,11 @@ class GeoSeries(GeoFrame, pspd.Series):
         GeoSeries.isna : inverse of notna
         GeoSeries.is_empty : detect empty geometries
         """
-        col = self.get_first_geometry_column()
-        select = f"`{col}` IS NOT NULL"
-
+        # After Sedona's minimum spark version is 3.5.0, we can use F.isnotnull(self.spark.column) instead
+        spark_expr = ~F.isnull(self.spark.column)
         result = self._query_geometry_column(
-            select, col, rename="notna", returns_geom=False
+            spark_expr,
+            returns_geom=False,
         )
         return to_bool(result)
 
@@ -3828,45 +3855,45 @@ class GeoSeries(GeoFrame, pspd.Series):
                 "GeoSeries.fillna() with limit is not implemented yet."
             )
 
-        col = self.get_first_geometry_column()
+        align = True
+
         if pd.isna(value) == True or isinstance(value, BaseGeometry):
             if (
                 value is not None and pd.isna(value) == True
             ):  # ie. value is np.nan or pd.NA:
-                value = "NULL"
+                value = None
             else:
                 if value is None:
                     from shapely.geometry import GeometryCollection
 
                     value = GeometryCollection()
 
-                value = f"ST_GeomFromText('{value.wkt}')"
+            other, extended = self._make_series_of_val(value)
+            align = False if extended else align
 
-            select = f"COALESCE(`{col}`, {value})"
-            result = self._query_geometry_column(select, col, "")
         elif isinstance(value, (GeoSeries, GeometryArray, gpd.GeoSeries)):
 
             if not isinstance(value, GeoSeries):
                 value = GeoSeries(value)
 
             # Replace all None's with empty geometries (this is a recursive call)
-            value = value.fillna(None)
+            other = value.fillna(None)
 
-            # Coalesce: If the value in L is null, use the corresponding value in R for that row
-            select = f"COALESCE(`L`, `R`)"
-            result = self._row_wise_operation(
-                select,
-                value,
-                align=None,
-                rename="fillna",
-                returns_geom=True,
-                default_val=None,
-            )
         else:
             raise ValueError(f"Invalid value type: {type(value)}")
 
+        # Coalesce: If the value in L is null, use the corresponding value in R for that row
+        spark_expr = F.coalesce(F.col("L"), F.col("R"))
+        result = self._row_wise_operation(
+            spark_expr,
+            other,
+            align=align,
+            returns_geom=True,
+            default_val=None,
+        )
+
         if inplace:
-            self._update_anchor(_to_spark_pandas_df(result))
+            self._update_inplace(result)
             return None
 
         return result
@@ -3971,11 +3998,13 @@ class GeoSeries(GeoFrame, pspd.Series):
         if old_crs.is_exact_same(crs):
             return self
 
-        col = self.get_first_geometry_column()
+        spark_expr = stf.ST_Transform(
+            self.spark.column,
+            F.lit(f"EPSG:{old_crs.to_epsg()}"),
+            F.lit(f"EPSG:{crs.to_epsg()}"),
+        )
         return self._query_geometry_column(
-            f"ST_Transform(`{col}`, 'EPSG:{old_crs.to_epsg()}', 'EPSG:{crs.to_epsg()}')",
-            col,
-            "",
+            spark_expr,
         )
 
     @property
@@ -4007,26 +4036,16 @@ class GeoSeries(GeoFrame, pspd.Series):
         1  POLYGON ((0 0, 1 1, 1 0, 0 0))   0.0   0.0   1.0   1.0
         2           LINESTRING (0 1, 1 2)   0.0   1.0   1.0   2.0
         """
-        col = self.get_first_geometry_column()
-
         selects = [
-            f"ST_XMin(`{col}`) as minx",
-            f"ST_YMin(`{col}`) as miny",
-            f"ST_XMax(`{col}`) as maxx",
-            f"ST_YMax(`{col}`) as maxy",
+            stf.ST_XMin(self.spark.column).alias("minx"),
+            stf.ST_YMin(self.spark.column).alias("miny"),
+            stf.ST_XMax(self.spark.column).alias("maxx"),
+            stf.ST_YMax(self.spark.column).alias("maxy"),
         ]
 
         df = self._internal.spark_frame
 
-        data_type = df.schema[col].dataType
-
-        if isinstance(data_type, BinaryType):
-            selects = [
-                select.replace(f"`{col}`", f"ST_GeomFromWKB(`{col}`)")
-                for select in selects
-            ]
-
-        sdf = df.selectExpr(*selects)
+        sdf = df.select(*selects)
         internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=None,
@@ -4242,18 +4261,12 @@ class GeoSeries(GeoFrame, pspd.Series):
         dtype: object
 
         """
-        col = self.get_first_geometry_column()
-        select = f"ST_AsBinary(`{col}`)"
+        spark_expr = stf.ST_AsBinary(self.spark.column)
 
         if hex:
-            # this is using pyspark's hex function since Sedona doesn't support hex WKB conversion at the moment
-            # (it only supports hex EWKB)
-            select = f"hex({select})"
-
+            spark_expr = F.hex(spark_expr)
         return self._query_geometry_column(
-            select,
-            cols=col,
-            rename="to_wkb",
+            spark_expr,
             returns_geom=False,
         )
 
@@ -4293,9 +4306,9 @@ class GeoSeries(GeoFrame, pspd.Series):
         --------
         GeoSeries.to_wkb
         """
-        return self._process_geometry_column(
-            "ST_AsText",
-            rename="to_wkt",
+        spark_expr = stf.ST_AsText(self.spark.column)
+        return self._query_geometry_column(
+            spark_expr,
             returns_geom=False,
         )
 
@@ -4313,22 +4326,28 @@ class GeoSeries(GeoFrame, pspd.Series):
     # # Utils
     # -----------------------------------------------------------------------------
 
-    def get_first_geometry_column(self) -> str:
-        first_binary_or_geometry_col = next(
-            (
-                field.name
-                for field in self._internal.spark_frame.schema.fields
-                if isinstance(field.dataType, BinaryType)
-                or field.dataType.typeName() == "geometrytype"
-            ),
-            None,
-        )
-        if first_binary_or_geometry_col:
-            return first_binary_or_geometry_col
+    def _update_inplace(self, result: "GeoSeries"):
+        self.rename(result.name, inplace=True)
+        self._update_anchor(result._anchor)
 
-        raise ValueError(
-            "get_first_geometry_column: No geometry column found in the GeoSeries."
-        )
+    def _make_series_of_val(self, value: Any):
+        """
+        A helper method to turn single objects into series (ps.Series or GeoSeries when possible)
+        Returns:
+            tuple[pspd.Series, bool]:
+                - The series of the value
+                - Whether returned value was a single object extended into a series (useful for row-wise 'align' parameter)
+        """
+        # generator instead of a in-memory list
+        if not isinstance(value, pspd.Series):
+            lst = [value for _ in range(len(self))]
+            if isinstance(value, BaseGeometry):
+                return GeoSeries(lst), True
+            else:
+                # e.g int input
+                return pspd.Series(lst), True
+        else:
+            return value, False
 
 
 # -----------------------------------------------------------------------------
@@ -4336,25 +4355,8 @@ class GeoSeries(GeoFrame, pspd.Series):
 # -----------------------------------------------------------------------------
 
 
-def _get_first_column_name(series: pspd.Series) -> str:
-    """
-    Get the first column name of a Series.
-
-    Parameters:
-    - series: The input Series.
-
-    Returns:
-    - str: The first column name of the Series.
-    """
-    return next(
-        field.name
-        for field in series._internal.spark_frame.schema.fields
-        if field.name not in (SPARK_DEFAULT_INDEX_NAME, NATURAL_ORDER_COLUMN_NAME)
-    )
-
-
-def _to_spark_pandas_df(ps_series: pspd.Series) -> pspd.DataFrame:
-    return pspd.DataFrame(ps_series._psdf._internal)
+def _get_series_col_name(ps_series: pspd.Series) -> str:
+    return ps_series.name if ps_series.name else SPARK_DEFAULT_SERIES_NAME
 
 
 def to_bool(ps_series: pspd.Series, default: bool = False) -> pspd.Series:

--- a/python/sedona/geopandas/geoseries.py
+++ b/python/sedona/geopandas/geoseries.py
@@ -4285,6 +4285,9 @@ class GeoSeries(GeoFrame, pspd.Series):
 
         *kwargs* that will be passed to json.dumps().
 
+        Note: Unlike geopandas, Sedona's implementation will replace 'LinearRing'
+        with 'LineString' in the GeoJSON output.
+
         Returns
         -------
         JSON string

--- a/python/sedona/geopandas/io.py
+++ b/python/sedona/geopandas/io.py
@@ -1,0 +1,238 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from typing import Union
+import warnings
+import pyspark.pandas as ps
+from sedona.geopandas import GeoDataFrame
+from pyspark.pandas.utils import default_session, scol_for
+from pyspark.pandas.internal import SPARK_DEFAULT_INDEX_NAME, NATURAL_ORDER_COLUMN_NAME
+from pyspark.pandas.frame import InternalFrame
+from pyspark.pandas.utils import validate_mode, log_advice
+from pandas.api.types import is_integer_dtype
+
+
+def _to_file(
+    df: GeoDataFrame,
+    path: str,
+    driver: Union[str, None] = None,
+    index: Union[bool, None] = True,
+    **kwargs,
+):
+    """
+    Write the ``GeoDataFrame`` to a file.
+
+    Parameters
+    ----------
+    path : string
+        File path or file handle to write to.
+    driver : string, default None
+        The format driver used to write the file.
+        If not specified, it attempts to infer it from the file extension.
+        If no extension is specified, Sedona will error.
+        Options:
+            - "geojson"
+            - "geopackage"
+            - "geoparquet"
+    schema : dict, default None
+        Not applicable to Sedona's implementation
+    index : bool, default None
+        If True, write index into one or more columns (for MultiIndex).
+        Default None writes the index into one or more columns only if
+        the index is named, is a MultiIndex, or has a non-integer data
+        type. If False, no index is written.
+    mode : string, default 'w'
+        The write mode, 'w' to overwrite the existing file and 'a' to append.
+        'overwrite' and 'append' are equivalent to 'w' and 'a' respectively.
+    crs : pyproj.CRS, default None
+        If specified, the CRS is passed to Fiona to
+        better control how the file is written. If None, GeoPandas
+        will determine the crs based on crs df attribute.
+        The value can be anything accepted
+        by :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
+    engine : str
+        Not applicable to Sedona's implementation
+    metadata : dict[str, str], default None
+        Optional metadata to be stored in the file. Keys and values must be
+        strings. Supported only for "GPKG" driver. Not supported by Sedona
+    **kwargs :
+        Keyword args to be passed to the engine, and can be used to write
+        to multi-layer data, store data within archives (zip files), etc.
+        In case of the "pyogrio" engine, the keyword arguments are passed to
+        `pyogrio.write_dataframe`. In case of the "fiona" engine, the keyword
+        arguments are passed to fiona.open`. For more information on possible
+        keywords, type: ``import pyogrio; help(pyogrio.write_dataframe)``.
+
+    Examples
+    --------
+
+    >>> gdf = GeoDataFrame({"geometry": [Point(0, 0), LineString([(0, 0), (1, 1)])], "int": [1, 2]}
+    >>> gdf.to_file(filepath, format="geoparquet")
+
+    With selected drivers you can also append to a file with `mode="a"`:
+
+    >>> gdf.to_file(gdf, driver="geojson", mode="a")
+
+    When the index is of non-integer dtype, index=None (default) is treated as True, writing the index to the file.
+
+    >>> gdf = GeoDataFrame({"geometry": [Point(0, 0)]}, index=["a", "b"])
+    >>> gdf.to_file(gdf, driver="geoparquet")
+    """
+
+    ext_to_driver = {
+        ".parquet": "Parquet",
+        ".json": "GeoJSON",
+        ".geojson": "GeoJSON",
+    }
+
+    # auto detect driver from filename if not provided
+    if driver is None:
+        _, extension = os.path.splitext(path)
+        if extension not in ext_to_driver:
+            raise ValueError(f"Unsupported file extension: {extension}")
+        driver = ext_to_driver[extension]
+
+    spark_fmt = driver.lower()
+
+    crs = kwargs.pop("crs", None)
+    if crs:
+        from pyproj import CRS
+
+        crs = CRS.from_user_input(crs)
+
+    spark_df = df._internal.spark_frame.drop(NATURAL_ORDER_COLUMN_NAME)
+
+    if index is None:
+        # Determine if index attribute(s) should be saved to file
+        # (only if they are named or are non-integer)
+        index = list(df.index.names) != [None] or not is_integer_dtype(df.index.dtype)
+
+    if not index:
+        log_advice(
+            "If index is not True is not specified for `to_file`, "
+            "the existing index is lost when writing to a file."
+        )
+        spark_df = spark_df.drop(SPARK_DEFAULT_INDEX_NAME)
+
+    if spark_fmt == "geoparquet":
+        writer = spark_df.write.format("geoparquet")
+
+    elif spark_fmt == "geojson":
+        writer = spark_df.write.format("geojson")
+
+    else:
+        raise ValueError(f"Unsupported spark format: {spark_fmt}")
+
+    default_mode = "overwrite"
+    mode = validate_mode(kwargs.pop("mode", default_mode))
+
+    writer.mode(mode).save(path, **kwargs)
+
+
+def read_file(filename: str, format: Union[str, None] = None, **kwargs):
+    """
+    Alternate constructor to create a ``GeoDataFrame`` from a file.
+
+    Parameters
+    ----------
+    filename : str
+        File path or file handle to read from. If the path is a directory,
+        Sedona will read all files in the directory into a dataframe.
+    format : str, default None
+        The format of the file to read. If None, Sedona will infer the format
+        from the file extension. Note, inferring the format from the file extension
+        is not supported for directories.
+        Options:
+            - "shapefile"
+            - "geojson"
+            - "geopackage"
+            - "geoparquet"
+
+    table_name : str, default None
+        The name of the table to read from a geopackage file. Required if format is geopackage.
+
+    See also
+    --------
+    GeoDataFrame.to_file : write GeoDataFrame to file
+    """
+
+    # We warn the user if they try to use arguments that geopandas supports but not Sedona
+    if kwargs:
+        warnings.warn(f"The given arguments are not supported in Sedona: {kwargs}")
+
+    spark = default_session()
+
+    # If format is not specified, infer it from the file extension
+    if format is None:
+        if os.path.isdir(filename):
+            raise ValueError(
+                f"Inferring the format from the file extension is not supported for directories: {filename}"
+            )
+        if filename.lower().endswith(".shp"):
+            format = "shapefile"
+        elif filename.lower().endswith(".json"):
+            format = "geojson"
+        elif filename.lower().endswith(".parquet"):
+            format = "geoparquet"
+        elif filename.lower().endswith(".gpkg"):
+            format = "geopackage"
+        else:
+            raise ValueError(f"Unsupported file type: {filename}")
+    else:
+        format = format.lower()
+
+    if format == "shapefile":
+        sdf = spark.read.format("shapefile").load(filename)
+        return GeoDataFrame(sdf)
+    elif format == "geojson":
+        sdf = (
+            spark.read.format("geojson")
+            .option("multiLine", "true")
+            .load(filename)
+            .select(
+                "geometry", f"properties.*"
+            )  # select all non-geometry columns (which are under properties)
+        )
+        # geojson also has a 'type' field, but we ignore it
+
+    elif format == "geopackage":
+        table_name = kwargs.get("table_name", None)
+        if not table_name:
+            raise ValueError("table_name is required for geopackage")
+        sdf = (
+            spark.read.format("geopackage")
+            .option("tableName", table_name)
+            .load(filename)
+        )
+
+    elif format == "geoparquet":
+        sdf = spark.read.format("geoparquet").load(filename)
+
+    else:
+        raise NotImplementedError(f"Unsupported file type: {filename}")
+
+    index_spark_columns = []
+
+    # If index was retained, we sort by it so the dataframe has the same order as the original one
+    if SPARK_DEFAULT_INDEX_NAME in sdf.columns:
+        sdf = sdf.orderBy(SPARK_DEFAULT_INDEX_NAME)
+        index_spark_columns = [scol_for(sdf, SPARK_DEFAULT_INDEX_NAME)]
+
+    internal = InternalFrame(spark_frame=sdf, index_spark_columns=index_spark_columns)
+    return GeoDataFrame(ps.DataFrame(internal))

--- a/python/sedona/geopandas/tools/sjoin.py
+++ b/python/sedona/geopandas/tools/sjoin.py
@@ -166,7 +166,8 @@ def _frame_join(
     final_columns = []
 
     # Add geometry column (always from left for geopandas compatibility)
-    final_columns.append("l_geometry as geometry")
+    # Currently, Sedona stores geometries in EWKB format
+    final_columns.append("ST_AsEWKB(l_geometry) as geometry")
 
     # Add other columns with suffix handling
     left_data_cols = [col for col in left_geo_df.columns if col != "l_geometry"]

--- a/python/sedona/geopandas/tools/sjoin.py
+++ b/python/sedona/geopandas/tools/sjoin.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
+import pyspark.pandas as ps
 from pyspark.pandas.internal import InternalFrame
 from pyspark.pandas.series import first_series
 from pyspark.pandas.utils import scol_for
@@ -22,8 +23,6 @@ from pyspark.sql.functions import expr, col, lit
 from pyspark.sql.types import StructType, StructField, StringType, IntegerType
 
 from sedona.geopandas import GeoDataFrame, GeoSeries
-from sedona.geopandas.geoseries import _to_geo_series
-from pyspark.pandas.frame import DataFrame as PandasOnSparkDataFrame
 
 # Pre-compiled regex pattern for suffix validation
 SUFFIX_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -209,7 +208,7 @@ def _frame_join(
             data_fields=[left_df._internal.data_fields[0]],
             column_label_names=left_df._internal.column_label_names,
         )
-        return _to_geo_series(first_series(PandasOnSparkDataFrame(internal)))
+        return _to_geo_series(first_series(ps.DataFrame(internal)))
     else:
         # Return GeoDataFrame for GeoDataFrame inputs
         return GeoDataFrame(result_df)
@@ -360,3 +359,16 @@ def _basic_checks(left_df, right_df, how, lsuffix, rsuffix, on_attribute=None):
         raise ValueError(f"lsuffix '{lsuffix}' contains invalid characters")
     if not SUFFIX_PATTERN.match(rsuffix):
         raise ValueError(f"rsuffix '{rsuffix}' contains invalid characters")
+
+
+def _to_geo_series(df: ps.Series) -> GeoSeries:
+    """
+    Get the first Series from the DataFrame.
+
+    Parameters:
+    - df: The input DataFrame.
+
+    Returns:
+    - GeoSeries: The first Series from the DataFrame.
+    """
+    return GeoSeries(data=df)

--- a/python/sedona/spark/__init__.py
+++ b/python/sedona/spark/__init__.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from sedona.spark.core import Envelope
-from sedona.spark.sql.functions import sedona_vectorized_udf
 
 try:
     import pyspark
@@ -24,16 +22,7 @@ except ImportError:
         "Apache Sedona requires PySpark. Please install PySpark before using Sedona spark."
     )
 
-from sedona.spark.core.enums import FileDataSplitter, GridType, IndexType
-from sedona.spark.core.formatMapper import GeoJsonReader, WkbReader, WktReader
-from sedona.spark.core.formatMapper.shapefileParser import ShapefileReader
-from sedona.spark.core.spatialOperator import (
-    JoinQuery,
-    JoinQueryRaw,
-    KNNQuery,
-    RangeQuery,
-    RangeQueryRaw,
-)
+from sedona.spark.SedonaContext import SedonaContext
 from sedona.spark.core.SpatialRDD import (
     CircleRDD,
     LineStringRDD,
@@ -42,17 +31,40 @@ from sedona.spark.core.SpatialRDD import (
     RectangleRDD,
     SpatialRDD,
 )
+from sedona.spark.core.enums import FileDataSplitter, GridType, IndexType
+from sedona.spark.core.formatMapper import GeoJsonReader, WkbReader, WktReader
+from sedona.spark.core.formatMapper.shapefileParser import ShapefileReader
+from sedona.spark.core.geom.circle import Circle
+from sedona.spark.core.geom.envelope import Envelope
+from sedona.spark.core.geom.geography import Geography
+from sedona.spark.core.spatialOperator import (
+    JoinQuery,
+    JoinQueryRaw,
+    KNNQuery,
+    RangeQuery,
+    RangeQueryRaw,
+)
+from sedona.spark.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.geoarrow.geoarrow import dataframe_to_arrow
 from sedona.spark.maps.SedonaKepler import SedonaKepler
 from sedona.spark.maps.SedonaPyDeck import SedonaPyDeck
 from sedona.spark.raster_utils.SedonaUtils import SedonaUtils
 from sedona.spark.register import SedonaRegistrator
-from sedona.spark.SedonaContext import SedonaContext
+from sedona.spark.sql.functions import sedona_vectorized_udf
 from sedona.spark.sql.st_aggregates import *
 from sedona.spark.sql.st_constructors import *
 from sedona.spark.sql.st_functions import *
 from sedona.spark.sql.st_predicates import *
 from sedona.spark.sql.types import GeometryType, GeographyType, RasterType
+from sedona.spark.stac import Client
+from sedona.spark.stac.collection_client import CollectionClient
+from sedona.spark.stats.clustering.dbscan import dbscan
+from sedona.spark.stats.hotspot_detection.getis_ord import g_local
+from sedona.spark.stats.weighting import (
+    add_distance_band_column,
+    add_binary_distance_band_column,
+)
 from sedona.spark.utils import KryoSerializer, SedonaKryoRegistrator
 from sedona.spark.utils.adapter import Adapter
+from sedona.spark.utils.spatial_rdd_parser import GeoData
 from sedona.spark.utils.structured_adapter import StructuredAdapter
-from sedona.spark.geoarrow.geoarrow import dataframe_to_arrow

--- a/python/sedona/spark/geoarrow/__init__.py
+++ b/python/sedona/spark/geoarrow/__init__.py
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe
+from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
 
-__all__ = ["create_spatial_dataframe"]
+__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/spark/sql/__init__.py
+++ b/python/sedona/spark/sql/__init__.py
@@ -15,20 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import inspect
+import sys
+
 # These allow use to access the __all__
 import sedona.spark.sql.st_aggregates as st_aggregates
 import sedona.spark.sql.st_constructors as st_constructors
 import sedona.spark.sql.st_functions as st_functions
 import sedona.spark.sql.st_predicates as st_predicates
+from sedona.spark.sql.functions import sedona_vectorized_udf
 
 # These bring the contents of the modules into this module
 from sedona.spark.sql.st_aggregates import *
 from sedona.spark.sql.st_constructors import *
 from sedona.spark.sql.st_functions import *
 from sedona.spark.sql.st_predicates import *
-import inspect
-import sys
-
+from sedona.spark.sql.types import GeometryType, GeographyType, RasterType
 
 __all__ = (
     [

--- a/python/sedona/spark/sql/st_functions.py
+++ b/python/sedona/spark/sql/st_functions.py
@@ -1703,7 +1703,9 @@ def ST_SetSRID(geometry: ColumnOrName, srid: Union[ColumnOrName, int]) -> Column
 
 @validate_argument_types
 def ST_Snap(
-    input: ColumnOrName, reference: ColumnOrName, tolerance: Union[ColumnOrName, float]
+    input: ColumnOrName,
+    reference: ColumnOrName,
+    tolerance: Union[ColumnOrName, float, int],
 ) -> Column:
     """Snaps input Geometry to reference Geometry controlled by distance tolerance.
 

--- a/python/sedona/spark/stac/client.py
+++ b/python/sedona/spark/stac/client.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Union, Optional, Iterator
+from typing import Union, Optional, Iterator, List
 
 from sedona.spark.stac.collection_client import CollectionClient
 
 import datetime as python_datetime
 from pystac import Item as PyStacItem
+from shapely.geometry.base import BaseGeometry
 
 from pyspark.sql import DataFrame
 
@@ -77,6 +78,9 @@ class Client:
         *ids: Union[str, list],
         collection_id: Optional[str] = None,
         bbox: Optional[list] = None,
+        geometry: Optional[
+            Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]
+        ] = None,
         datetime: Optional[Union[str, python_datetime.datetime, list]] = None,
         max_items: Optional[int] = None,
         return_dataframe: bool = True,
@@ -94,6 +98,11 @@ class Client:
         - bbox (Optional[list]): A list of bounding boxes for filtering the items.
           Each bounding box is represented as a list of four float values: [min_lon, min_lat, max_lon, max_lat].
           Example: [[-180.0, -90.0, 180.0, 90.0]]  # This bounding box covers the entire world.
+
+        - geometry (Optional[Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]]): Shapely geometry object(s) or WKT string(s) for spatial filtering.
+          Can be a single geometry, WKT string, or a list of geometries/WKT strings.
+          If both bbox and geometry are provided, geometry takes precedence.
+          Example: Polygon(...) or "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))" or [Polygon(...), Polygon(...)]
 
         - datetime (Optional[Union[str, python_datetime.datetime, list]]): A single datetime, RFC 3339-compliant timestamp,
           or a list of date-time ranges for filtering the items. The datetime can be specified in various formats:
@@ -119,9 +128,17 @@ class Client:
             client = self.get_collection_from_catalog()
         if return_dataframe:
             return client.get_dataframe(
-                *ids, bbox=bbox, datetime=datetime, max_items=max_items
+                *ids,
+                bbox=bbox,
+                geometry=geometry,
+                datetime=datetime,
+                max_items=max_items,
             )
         else:
             return client.get_items(
-                *ids, bbox=bbox, datetime=datetime, max_items=max_items
+                *ids,
+                bbox=bbox,
+                geometry=geometry,
+                datetime=datetime,
+                max_items=max_items,
             )

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -105,7 +105,7 @@ class CollectionClient:
         df: DataFrame, bbox=None, geometry=None, datetime=None
     ) -> DataFrame:
         """
-        This function applies spatial and temporal filters to a Spark DataFrame.
+        This function applies spatial and temporal filters to a Spark DataFrame using safe parameterized operations.
 
         Parameters:
         - df (DataFrame): The input Spark DataFrame to be filtered.
@@ -121,51 +121,150 @@ class CollectionClient:
         Returns:
         - DataFrame: The filtered Spark DataFrame.
 
-        The function constructs SQL conditions for spatial and temporal filters and applies them to the DataFrame.
-        If geometry is provided, it takes precedence over bbox for spatial filtering.
-        If bbox is provided (and no geometry), it constructs spatial conditions using st_intersects and ST_GeomFromText.
-        If datetime is provided, it constructs temporal conditions using the datetime column.
-        The conditions are combined using OR logic.
+        The function uses Spark SQL column operations and functions instead of string concatenation
+        to prevent SQL injection vulnerabilities. Spatial and temporal conditions are combined using OR logic.
         """
+        from pyspark.sql import functions as F
+        from pyspark.sql.functions import col, lit
+
         # Geometry takes precedence over bbox
         if geometry:
             geometry_conditions = []
             for geom in geometry:
-                if isinstance(geom, str):
-                    # Assume it's WKT
-                    geom_wkt = geom
-                elif hasattr(geom, "wkt"):
-                    # Shapely geometry object
-                    geom_wkt = geom.wkt
-                else:
-                    # Try to convert to string (fallback)
-                    geom_wkt = str(geom)
-                geometry_conditions.append(
-                    f"st_intersects(ST_GeomFromText('{geom_wkt}'), geometry)"
-                )
-            geometry_sql_condition = " OR ".join(geometry_conditions)
-            df = df.filter(geometry_sql_condition)
+                try:
+                    # Validate and sanitize geometry input
+                    if isinstance(geom, str):
+                        # Validate WKT format basic structure
+                        if not geom.strip() or any(
+                            char in geom for char in ["'", '"', ";", "--", "/*", "*/"]
+                        ):
+                            raise ValueError("Invalid WKT geometry string")
+                        geom_wkt = geom.strip()
+                    elif hasattr(geom, "wkt"):
+                        # Shapely geometry object
+                        geom_wkt = geom.wkt
+                    else:
+                        # Try to convert to string (fallback)
+                        geom_str = str(geom)
+                        if not geom_str.strip() or any(
+                            char in geom_str
+                            for char in ["'", '"', ";", "--", "/*", "*/"]
+                        ):
+                            raise ValueError("Invalid geometry string")
+                        geom_wkt = geom_str.strip()
+
+                    # Use Spark SQL functions with safe literal values
+                    from pyspark.sql.functions import expr
+
+                    geometry_conditions.append(
+                        expr(
+                            "st_intersects(ST_GeomFromText('{}'), geometry)".format(
+                                geom_wkt.replace("'", "''")
+                            )
+                        )
+                    )
+                except (ValueError, TypeError, AttributeError):
+                    # Skip invalid geometries rather than failing  # nosec B112
+                    continue
+
+            if geometry_conditions:
+                # Combine conditions with OR using reduce
+                from functools import reduce
+
+                combined_condition = reduce(lambda a, b: a | b, geometry_conditions)
+                df = df.filter(combined_condition)
+
         elif bbox:
             bbox_conditions = []
             for bbox_item in bbox:
-                polygon_wkt = (
-                    f"POLYGON(({bbox_item[0]} {bbox_item[1]}, {bbox_item[2]} {bbox_item[1]}, "
-                    f"{bbox_item[2]} {bbox_item[3]}, {bbox_item[0]} {bbox_item[3]}, {bbox_item[0]} {bbox_item[1]}))"
-                )
-                bbox_conditions.append(
-                    f"st_intersects(ST_GeomFromText('{polygon_wkt}'), geometry)"
-                )
-            bbox_sql_condition = " OR ".join(bbox_conditions)
-            df = df.filter(bbox_sql_condition)
+                try:
+                    # Validate bbox parameters are numeric
+                    if len(bbox_item) != 4:
+                        continue
+
+                    min_lon, min_lat, max_lon, max_lat = bbox_item
+
+                    # Validate numeric values and reasonable ranges
+                    for coord in [min_lon, min_lat, max_lon, max_lat]:
+                        if (
+                            not isinstance(coord, (int, float)) or coord != coord
+                        ):  # NaN check
+                            raise ValueError("Invalid coordinate")
+
+                    # Validate longitude/latitude ranges
+                    if not (-180 <= min_lon <= 180 and -180 <= max_lon <= 180):
+                        continue
+                    if not (-90 <= min_lat <= 90 and -90 <= max_lat <= 90):
+                        continue
+
+                    # Create polygon using validated numeric values
+                    polygon_wkt = "POLYGON(({} {}, {} {}, {} {}, {} {}, {} {}))".format(
+                        float(min_lon),
+                        float(min_lat),
+                        float(max_lon),
+                        float(min_lat),
+                        float(max_lon),
+                        float(max_lat),
+                        float(min_lon),
+                        float(max_lat),
+                        float(min_lon),
+                        float(min_lat),
+                    )
+
+                    bbox_conditions.append(
+                        F.expr(
+                            f"st_intersects(ST_GeomFromText('{polygon_wkt}'), geometry)"
+                        )
+                    )
+
+                except (ValueError, TypeError, IndexError):
+                    # Skip invalid bbox items rather than failing
+                    continue
+
+            if bbox_conditions:
+                # Combine conditions with OR using reduce
+                from functools import reduce
+
+                combined_condition = reduce(lambda a, b: a | b, bbox_conditions)
+                df = df.filter(combined_condition)
 
         if datetime:
             interval_conditions = []
             for interval in datetime:
-                interval_conditions.append(
-                    f"datetime BETWEEN '{interval[0]}' AND '{interval[1]}'"
-                )
-            interval_sql_condition = " OR ".join(interval_conditions)
-            df = df.filter(interval_sql_condition)
+                try:
+                    if len(interval) != 2:
+                        continue
+
+                    start_time, end_time = interval
+
+                    # Validate datetime strings (basic ISO format check)
+                    if not isinstance(start_time, str) or not isinstance(end_time, str):
+                        continue
+
+                    # Check for SQL injection patterns
+                    for time_str in [start_time, end_time]:
+                        if any(
+                            char in time_str
+                            for char in ["'", '"', ";", "--", "/*", "*/", chr(0)]
+                        ):
+                            raise ValueError("Invalid datetime string")
+
+                    # Use Spark column operations instead of string concatenation
+                    condition = (col("datetime") >= lit(start_time)) & (
+                        col("datetime") <= lit(end_time)
+                    )
+                    interval_conditions.append(condition)
+
+                except (ValueError, TypeError, IndexError):
+                    # Skip invalid datetime intervals rather than failing
+                    continue
+
+            if interval_conditions:
+                # Combine conditions with OR using reduce
+                from functools import reduce
+
+                combined_condition = reduce(lambda a, b: a | b, interval_conditions)
+                df = df.filter(combined_condition)
 
         return df
 

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -366,8 +366,10 @@ class CollectionClient:
             if datetime:
                 if isinstance(datetime, (str, python_datetime.datetime)):
                     datetime = [self._expand_date(str(datetime))]
-                elif isinstance(datetime, list) and isinstance(datetime[0], str):
-                    datetime = [datetime]
+                elif isinstance(datetime, (list, tuple)) and isinstance(
+                    datetime[0], str
+                ):
+                    datetime = [list(datetime)]
             # Apply spatial and temporal filters
             df = self._apply_spatial_temporal_filters(df, bbox, datetime)
         # Limit the number of items if max_items is specified

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -257,9 +257,9 @@ class CollectionClient:
             # Return an iterator of the items
             return iter(items)
         except Exception as e:
-            # Log the error and raise a RuntimeError
-            logging.error(f"Error getting items: {e}")
-            raise RuntimeError("Failed to get items") from e
+            # Log error type without exposing sensitive details
+            logging.error(f"Error getting items: {type(e).__name__}")
+            raise RuntimeError("Failed to get items") from None
 
     def get_dataframe(
         self,
@@ -303,8 +303,8 @@ class CollectionClient:
 
             return df
         except Exception as e:
-            logging.error(f"Error getting filtered dataframe: {e}")
-            raise RuntimeError("Failed to get filtered dataframe") from e
+            logging.error(f"Error getting filtered dataframe: {type(e).__name__}")
+            raise RuntimeError("Failed to get filtered dataframe") from None
 
     def save_to_geoparquet(
         self,
@@ -344,8 +344,8 @@ class CollectionClient:
             df_geoparquet.write.format("geoparquet").save(output_path)
             logging.info(f"DataFrame successfully saved to {output_path}")
         except Exception as e:
-            logging.error(f"Error saving DataFrame to GeoParquet: {e}")
-            raise RuntimeError("Failed to save DataFrame to GeoParquet") from e
+            logging.error(f"Error saving DataFrame to GeoParquet: {type(e).__name__}")
+            raise RuntimeError("Failed to save DataFrame to GeoParquet") from None
 
     @staticmethod
     def _convert_assets_schema(df: DataFrame) -> DataFrame:

--- a/python/sedona/spark/stac/collection_client.py
+++ b/python/sedona/spark/stac/collection_client.py
@@ -16,13 +16,14 @@
 # under the License.
 
 import logging
-from typing import Iterator, Union
+from typing import Iterator, Union, List
 from typing import Optional
 
 import datetime as python_datetime
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import dt
 from pystac import Item as PyStacItem
+from shapely.geometry.base import BaseGeometry
 
 
 def get_collection_url(url: str, collection_id: Optional[str] = None) -> str:
@@ -101,7 +102,7 @@ class CollectionClient:
 
     @staticmethod
     def _apply_spatial_temporal_filters(
-        df: DataFrame, bbox=None, datetime=None
+        df: DataFrame, bbox=None, geometry=None, datetime=None
     ) -> DataFrame:
         """
         This function applies spatial and temporal filters to a Spark DataFrame.
@@ -111,6 +112,8 @@ class CollectionClient:
         - bbox (Optional[list]): A list of bounding boxes for filtering the items.
           Each bounding box is represented as a list of four float values: [min_lon, min_lat, max_lon, max_lat].
           Example: [[-180.0, -90.0, 180.0, 90.0]]  # This bounding box covers the entire world.
+        - geometry (Optional[list]): A list of geometry objects (Shapely or WKT) for spatial filtering.
+          If both bbox and geometry are provided, geometry takes precedence.
         - datetime (Optional[list]): A list of date-time ranges for filtering the items.
           Each date-time range is represented as a list of two strings in ISO 8601 format: [start_datetime, end_datetime].
           Example: [["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]  # This interval covers the entire year of 2020.
@@ -119,16 +122,35 @@ class CollectionClient:
         - DataFrame: The filtered Spark DataFrame.
 
         The function constructs SQL conditions for spatial and temporal filters and applies them to the DataFrame.
-        If bbox is provided, it constructs spatial conditions using st_intersects and ST_GeomFromText.
+        If geometry is provided, it takes precedence over bbox for spatial filtering.
+        If bbox is provided (and no geometry), it constructs spatial conditions using st_intersects and ST_GeomFromText.
         If datetime is provided, it constructs temporal conditions using the datetime column.
         The conditions are combined using OR logic.
         """
-        if bbox:
+        # Geometry takes precedence over bbox
+        if geometry:
+            geometry_conditions = []
+            for geom in geometry:
+                if isinstance(geom, str):
+                    # Assume it's WKT
+                    geom_wkt = geom
+                elif hasattr(geom, "wkt"):
+                    # Shapely geometry object
+                    geom_wkt = geom.wkt
+                else:
+                    # Try to convert to string (fallback)
+                    geom_wkt = str(geom)
+                geometry_conditions.append(
+                    f"st_intersects(ST_GeomFromText('{geom_wkt}'), geometry)"
+                )
+            geometry_sql_condition = " OR ".join(geometry_conditions)
+            df = df.filter(geometry_sql_condition)
+        elif bbox:
             bbox_conditions = []
-            for bbox in bbox:
+            for bbox_item in bbox:
                 polygon_wkt = (
-                    f"POLYGON(({bbox[0]} {bbox[1]}, {bbox[2]} {bbox[1]}, "
-                    f"{bbox[2]} {bbox[3]}, {bbox[0]} {bbox[3]}, {bbox[0]} {bbox[1]}))"
+                    f"POLYGON(({bbox_item[0]} {bbox_item[1]}, {bbox_item[2]} {bbox_item[1]}, "
+                    f"{bbox_item[2]} {bbox_item[3]}, {bbox_item[0]} {bbox_item[3]}, {bbox_item[0]} {bbox_item[1]}))"
                 )
                 bbox_conditions.append(
                     f"st_intersects(ST_GeomFromText('{polygon_wkt}'), geometry)"
@@ -194,6 +216,9 @@ class CollectionClient:
         self,
         *ids: Union[str, list],
         bbox: Optional[list] = None,
+        geometry: Optional[
+            Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]
+        ] = None,
         datetime: Optional[Union[str, python_datetime.datetime, list]] = None,
         max_items: Optional[int] = None,
     ) -> Iterator[PyStacItem]:
@@ -204,6 +229,9 @@ class CollectionClient:
         optional filters to the data. The filters include:
         - IDs: A list of item IDs to filter the items. If not provided, no ID filtering is applied.
         - bbox (Optional[list]): A list of bounding boxes for filtering the items.
+        - geometry (Optional[Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]]): Shapely geometry object(s) or WKT string(s) for spatial filtering.
+          Can be a single geometry, WKT string, or a list of geometries/WKT strings.
+          If both bbox and geometry are provided, geometry takes precedence.
         - datetime (Optional[Union[str, python_datetime.datetime, list]]): A single datetime, RFC 3339-compliant timestamp,
           or a list of date-time ranges for filtering the items.
         - max_items (Optional[int]): The maximum number of items to return from the search, even if there are more matching results.
@@ -217,7 +245,7 @@ class CollectionClient:
           is raised with a message indicating the failure.
         """
         try:
-            df = self.load_items_df(bbox, datetime, ids, max_items)
+            df = self.load_items_df(bbox, geometry, datetime, ids, max_items)
 
             # Collect the filtered rows and convert them to PyStacItem objects
             items = []
@@ -237,6 +265,9 @@ class CollectionClient:
         self,
         *ids: Union[str, list],
         bbox: Optional[list] = None,
+        geometry: Optional[
+            Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]
+        ] = None,
         datetime: Optional[Union[str, python_datetime.datetime, list]] = None,
         max_items: Optional[int] = None,
     ) -> DataFrame:
@@ -251,6 +282,10 @@ class CollectionClient:
         - bbox (Optional[list]): A list of bounding boxes for filtering the items.
           Each bounding box is represented as a list of four float values: [min_lon, min_lat, max_lon, max_lat].
           Example: [[-180.0, -90.0, 180.0, 90.0]]  # This bounding box covers the entire world.
+        - geometry (Optional[Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]]): Shapely geometry object(s) or WKT string(s) for spatial filtering.
+          Can be a single geometry, WKT string, or a list of geometries/WKT strings.
+          If both bbox and geometry are provided, geometry takes precedence.
+          Example: Polygon(...) or "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))" or [Polygon(...), Polygon(...)]
         - datetime (Optional[Union[str, python_datetime.datetime, list]]): A single datetime, RFC 3339-compliant timestamp,
           or a list of date-time ranges for filtering the items.
           Example: "2020-01-01T00:00:00Z" or python_datetime.datetime(2020, 1, 1) or [["2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z"]]
@@ -264,7 +299,7 @@ class CollectionClient:
           is raised with a message indicating the failure.
         """
         try:
-            df = self.load_items_df(bbox, datetime, ids, max_items)
+            df = self.load_items_df(bbox, geometry, datetime, ids, max_items)
 
             return df
         except Exception as e:
@@ -276,6 +311,9 @@ class CollectionClient:
         *ids: Union[str, list],
         output_path: str,
         bbox: Optional[list] = None,
+        geometry: Optional[
+            Union[str, BaseGeometry, List[Union[str, BaseGeometry]]]
+        ] = None,
         datetime: Optional[list] = None,
     ) -> None:
         """
@@ -299,7 +337,9 @@ class CollectionClient:
           DataFrame to Parquet format, a RuntimeError is raised with a message indicating the failure.
         """
         try:
-            df = self.get_dataframe(*ids, bbox=bbox, datetime=datetime)
+            df = self.get_dataframe(
+                *ids, bbox=bbox, geometry=geometry, datetime=datetime
+            )
             df_geoparquet = self._convert_assets_schema(df)
             df_geoparquet.write.format("geoparquet").save(output_path)
             logging.info(f"DataFrame successfully saved to {output_path}")
@@ -342,9 +382,15 @@ class CollectionClient:
 
         return df
 
-    def load_items_df(self, bbox, datetime, ids, max_items):
+    def load_items_df(self, bbox, geometry, datetime, ids, max_items):
         # Load the collection data from the specified collection URL
-        if not ids and not bbox and not datetime and max_items is not None:
+        if (
+            not ids
+            and not bbox
+            and not geometry
+            and not datetime
+            and max_items is not None
+        ):
             df = (
                 self.spark.read.format("stac")
                 .option("itemsLimitMax", max_items)
@@ -362,6 +408,10 @@ class CollectionClient:
             # Ensure bbox is a list of lists
             if bbox and isinstance(bbox[0], float):
                 bbox = [bbox]
+            # Handle geometry parameter
+            if geometry:
+                if not isinstance(geometry, list):
+                    geometry = [geometry]
             # Handle datetime parameter
             if datetime:
                 if isinstance(datetime, (str, python_datetime.datetime)):
@@ -371,7 +421,7 @@ class CollectionClient:
                 ):
                     datetime = [list(datetime)]
             # Apply spatial and temporal filters
-            df = self._apply_spatial_temporal_filters(df, bbox, datetime)
+            df = self._apply_spatial_temporal_filters(df, bbox, geometry, datetime)
         # Limit the number of items if max_items is specified
         if max_items is not None:
             df = df.limit(max_items)

--- a/python/sedona/sql/__init__.py
+++ b/python/sedona/sql/__init__.py
@@ -14,15 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
-
-warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]

--- a/python/sedona/sql/st_aggregates.py
+++ b/python/sedona/sql/st_aggregates.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.sql import st_aggregates as sta
+from sedona.spark.sql.st_aggregates import *
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.sql.st_aggregates' is deprecated. Please use 'sedona.spark.sql.st_aggregates' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = sta.__all__

--- a/python/sedona/sql/st_constructors.py
+++ b/python/sedona/sql/st_constructors.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.sql import st_constructors as stc
+from sedona.spark.sql.st_constructors import *
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.sql.st_constructors' is deprecated. Please use 'sedona.spark.sql.st_constructors' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = stc.__all__

--- a/python/sedona/sql/st_functions.py
+++ b/python/sedona/sql/st_functions.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.sql import st_functions as stf
+from sedona.spark.sql.st_functions import *
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.sql.st_functions' is deprecated. Please use 'sedona.spark.sql.st_functions' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = stf.__all__

--- a/python/sedona/sql/st_predicates.py
+++ b/python/sedona/sql/st_predicates.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.sql import st_predicates as stp
+from sedona.spark.sql.st_predicates import *
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.sql.st_predicates' is deprecated. Please use 'sedona.spark.sql.st_predicates' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = stp.__all__

--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import warnings
-from sedona.spark.sql.types import GeographyType, GeometryType
+from sedona.spark.sql.types import GeographyType, GeometryType, RasterType
 
 warnings.warn(
     "Importing from 'sedona.sql.types' is deprecated. Please use 'sedona.spark.sql.types' instead.",
@@ -24,4 +24,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-__all__ = ["GeographyType", "GeometryType"]
+__all__ = ["GeographyType", "GeometryType", "RasterType"]

--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.sql.types import GeographyType, GeometryType
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.sql.types' is deprecated. Please use 'sedona.spark.sql.types' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["GeographyType", "GeometryType"]

--- a/python/sedona/stac/client.py
+++ b/python/sedona/stac/client.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.stac.client import Client
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.stac.client' is deprecated. Please use 'sedona.spark.stac.client' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["Client"]

--- a/python/sedona/stac/collection_client.py
+++ b/python/sedona/stac/collection_client.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.stac.collection_client import CollectionClient
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.stac.collection_client' is deprecated. Please use 'sedona.spark.stac.collection_client' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["CollectionClient"]

--- a/python/sedona/stats/hotspot_detection/getis_ord.py
+++ b/python/sedona/stats/hotspot_detection/getis_ord.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.stats.hotspot_detection.getis_ord import g_local
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.stats.hotspot_detection.getis_ord' is deprecated. Please use 'sedona.spark.stats.hotspot_detection.getis_ord' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["g_local"]

--- a/python/sedona/stats/hotspot_detection/getis_ord/__init__.py
+++ b/python/sedona/stats/hotspot_detection/getis_ord/__init__.py
@@ -24,3 +24,5 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+__all__ = ["g_local"]

--- a/python/sedona/stats/weighting/__init__.py
+++ b/python/sedona/stats/weighting/__init__.py
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sedona.spark.stats.weighting import add_binary_distance_band_column
+from sedona.spark.stats.weighting import (
+    add_distance_band_column,
+    add_binary_distance_band_column,
+)
 
 import warnings
 
@@ -24,3 +27,8 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+__all__ = [
+    "add_distance_band_column",
+    "add_binary_distance_band_column",
+]

--- a/python/sedona/utils/adapter.py
+++ b/python/sedona/utils/adapter.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.utils.adapter import Adapter
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.utils.adapter' is deprecated. Please use 'sedona.spark.utils.adapter' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["Adapter"]

--- a/python/sedona/utils/geoarrow.py
+++ b/python/sedona/utils/geoarrow.py
@@ -16,8 +16,7 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.geoarrow import create_spatial_dataframe, dataframe_to_arrow
 
 warnings.warn(
     "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",

--- a/python/sedona/utils/spatial_rdd_parser.py
+++ b/python/sedona/utils/spatial_rdd_parser.py
@@ -16,13 +16,12 @@
 # under the License.
 
 import warnings
-
-from sedona.spark.geoarrow.geoarrow import create_spatial_dataframe, dataframe_to_arrow
+from sedona.spark.utils.spatial_rdd_parser import GeoData
 
 warnings.warn(
-    "The 'sedona.geoarrow' module is deprecated and will be removed in future versions. Please use 'sedona.spark.geoarrow' instead.",
+    "Importing from 'sedona.utils.spatial_rdd_parser' is deprecated. Please use 'sedona.spark.utils.spatial_rdd_parser' instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["create_spatial_dataframe", "dataframe_to_arrow"]
+__all__ = ["GeoData"]

--- a/python/src/geom_buf.c
+++ b/python/src/geom_buf.c
@@ -221,8 +221,8 @@ SedonaErrorCode read_geom_buf_header(const char *buf, int buf_size,
   int geom_type_id = preamble >> 4;
   int coord_type = (preamble & 0x0F) >> 1;
   if ((preamble & 0x01) != 0) {
-    srid = (((unsigned int)buf[1]) << 16) | (((unsigned int)buf[2]) << 8) |
-           ((unsigned int)buf[3]);
+    srid = (((unsigned int)buf[1] & 0xFF) << 16) |
+           (((unsigned int)buf[2] & 0xFF) << 8) | ((unsigned int)buf[3] & 0xFF);
   }
   int num_coords = ((int *)buf)[1];
   if (geom_type_id < 0 || geom_type_id > GEOMETRYCOLLECTION) {

--- a/python/src/geomserde.c
+++ b/python/src/geomserde.c
@@ -645,11 +645,9 @@ SedonaErrorCode sedona_serialize_geom(GEOSContextHandle_t handle,
                                    p_buf_size);
       break;
     case GEOS_LINESTRING:
+    case GEOS_LINEARRING:
       err = sedona_serialize_linestring(handle, geom, srid, &cs_info, p_buf,
                                         p_buf_size);
-      break;
-    case GEOS_LINEARRING:
-      err = SEDONA_UNSUPPORTED_GEOM_TYPE;
       break;
     case GEOS_POLYGON:
       err = sedona_serialize_polygon(handle, geom, srid, &cs_info, p_buf,

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -20,6 +20,7 @@ import tempfile
 from shapely.geometry import (
     Point,
 )
+import shapely
 
 from sedona.geopandas import GeoDataFrame, GeoSeries
 from tests.geopandas.test_geopandas_base import TestGeopandasBase
@@ -32,6 +33,10 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestDataframe(TestGeopandasBase):
     @pytest.mark.parametrize(
         "obj",
@@ -42,18 +47,19 @@ class TestDataframe(TestGeopandasBase):
             gpd.GeoDataFrame([Point(x, x) for x in range(3)]),
             pd.Series([Point(x, x) for x in range(3)]),
             gpd.GeoSeries([Point(x, x) for x in range(3)]),
-            GeoSeries([Point(x, x) for x in range(3)]),
-            GeoDataFrame([Point(x, x) for x in range(3)]),
         ],
     )
     def test_constructor(self, obj):
         sgpd_df = GeoDataFrame(obj)
         check_geodataframe(sgpd_df)
 
+    # These need to be separate to make sure Sedona's Geometry UDTs have been registered
     def test_constructor_pandas_on_spark(self):
         for obj in [
             ps.DataFrame([Point(x, x) for x in range(3)]),
             ps.Series([Point(x, x) for x in range(3)]),
+            GeoSeries([Point(x, x) for x in range(3)]),
+            GeoDataFrame([Point(x, x) for x in range(3)]),
         ]:
             sgpd_df = GeoDataFrame(obj)
             check_geodataframe(sgpd_df)
@@ -268,23 +274,15 @@ class TestDataframe(TestGeopandasBase):
         data = {"geometry1": [poly1, poly2], "id": [1, 2], "value": ["a", "b"]}
 
         df = GeoDataFrame(data)
+        df.set_geometry("geometry1", inplace=True)
 
-        # Calculate area
-        area_df = df.area
+        area_series = df.area
 
-        # Verify result is a GeoDataFrame
-        assert type(area_df) is GeoDataFrame
-
-        # Verify the geometry column was converted to area values
-        assert "geometry1_area" in area_df.columns
-
-        # Verify non-geometry columns were preserved
-        assert "id" in area_df.columns
-        assert "value" in area_df.columns
+        assert type(area_series) is ps.Series
 
         # Check the actual area values
-        area_values = area_df["geometry1_area"].to_list()
-        assert len(area_values) == 2
+        area_values = area_series.to_list()
+        assert len(area_series) == 2
         self.assert_almost_equal(area_values[0], 1.0)
         self.assert_almost_equal(area_values[1], 4.0)
 

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -19,7 +19,14 @@ import tempfile
 
 from shapely.geometry import (
     Point,
+    LineString,
     Polygon,
+    GeometryCollection,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    LinearRing,
+    box,
 )
 import shapely
 
@@ -51,7 +58,8 @@ class TestDataframe(TestGeopandasBase):
         ],
     )
     def test_constructor(self, obj):
-        sgpd_df = GeoDataFrame(obj)
+        with self.ps_allow_diff_frames():
+            sgpd_df = GeoDataFrame(obj)
         check_geodataframe(sgpd_df)
 
     @pytest.mark.parametrize(
@@ -320,7 +328,6 @@ class TestDataframe(TestGeopandasBase):
 
     def test_buffer(self):
         # Create a GeoDataFrame with geometries to test buffer operation
-        from shapely.geometry import Polygon, Point
 
         # Create input geometries
         point = Point(0, 0)
@@ -352,6 +359,109 @@ class TestDataframe(TestGeopandasBase):
 
         # Check that square buffer area is greater than original (1.0)
         assert areas[1] > 1.0
+
+    def test_to_parquet(self):
+        pass
+
+    def test_from_arrow(self):
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        import pyarrow as pa
+
+        table = pa.table({"a": [0, 1, 2], "b": [0.1, 0.2, 0.3]})
+        with pytest.raises(ValueError, match="No geometry column found"):
+            GeoDataFrame.from_arrow(table)
+
+        gdf = gpd.GeoDataFrame(
+            {
+                "col": [1, 2, 3, 4],
+                "geometry": [
+                    LineString([(0, 0), (1, 1)]),
+                    box(0, 0, 10, 10),
+                    Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                    Point(1, 1),
+                ],
+            }
+        )
+
+        result = GeoDataFrame.from_arrow(gdf.to_arrow())
+        self.check_sgpd_df_equals_gpd_df(result, gdf)
+
+        gdf = gpd.GeoDataFrame(
+            {
+                "col": ["a", "b", "c", "d"],
+                "geometry": [
+                    Point(1, 1),
+                    Polygon(),
+                    LineString([(0, 0), (1, 1)]),
+                    None,
+                ],
+            }
+        )
+
+        result = GeoDataFrame.from_arrow(gdf.to_arrow())
+
+        self.check_sgpd_df_equals_gpd_df(result, gdf)
+
+    def test_to_json(self):
+        import json
+
+        d = {"col1": ["name1", "name2"], "geometry": [Point(1, 2), Point(2, 1)]}
+
+        # Currently, adding the crs information later requires us to join across partitions
+        with self.ps_allow_diff_frames():
+            gdf = GeoDataFrame(d, crs="EPSG:3857")
+
+        result = gdf.to_json()
+
+        obj = json.loads(result)
+        assert obj["type"] == "FeatureCollection"
+        assert obj["features"][0]["geometry"]["type"] == "Point"
+        assert obj["features"][0]["geometry"]["coordinates"] == [1.0, 2.0]
+        assert obj["features"][1]["geometry"]["type"] == "Point"
+        assert obj["features"][1]["geometry"]["coordinates"] == [2.0, 1.0]
+        assert obj["crs"]["type"] == "name"
+        assert obj["crs"]["properties"]["name"] == "urn:ogc:def:crs:EPSG::3857"
+
+        expected = '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", \
+"properties": {"col1": "name1"}, "geometry": {"type": "Point", "coordinates": [1.0,\
+ 2.0]}}, {"id": "1", "type": "Feature", "properties": {"col1": "name2"}, "geometry"\
+: {"type": "Point", "coordinates": [2.0, 1.0]}}], "crs": {"type": "name", "properti\
+es": {"name": "urn:ogc:def:crs:EPSG::3857"}}}'
+        assert result == expected, f"Expected {expected}, but got {result}"
+
+    def test_to_arrow(self):
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        import pyarrow as pa
+        from geopandas.testing import assert_geodataframe_equal
+
+        data = {"col1": ["name1", "name2"], "geometry": [Point(1, 2), Point(2, 1)]}
+
+        # Ensure index is not preserved for index=False
+        sgpd_df = GeoDataFrame(data, index=pd.Index([1, 2]))
+        result = pa.table(sgpd_df.to_arrow(index=False))
+
+        expected = gpd.GeoDataFrame(data)
+
+        # Ensure we can read it from using geopandas
+        gpd_df = gpd.GeoDataFrame.from_arrow(result)
+        assert_geodataframe_equal(gpd_df, expected)
+
+        # Ensure we can read it using sedona geopandas
+        sgpd_df = GeoDataFrame.from_arrow(result)
+        self.check_sgpd_df_equals_gpd_df(sgpd_df, expected)
+
+        # Ensure index is preserved for index=True
+        sgpd_df = GeoDataFrame(data, index=pd.Index([1, 2]))
+        result = pa.table(sgpd_df.to_arrow(index=True))
+
+        expected = gpd.GeoDataFrame(data, pd.Index([1, 2]))
+
+        gpd_df = gpd.GeoDataFrame.from_arrow(result)
+        assert_geodataframe_equal(gpd_df, expected)
 
 
 # -----------------------------------------------------------------------------

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -90,7 +90,7 @@ class TestDataframe(TestGeopandasBase):
         sgpd_df.set_geometry(name, inplace=True)
         check_geodataframe(sgpd_df)
         result = sgpd_df.area
-        expected = pd.Series([1.0, 1.0, 1.0], name=name)
+        expected = pd.Series([1.0, 1.0, 1.0])
         self.check_pd_series_equal(result, expected)
 
     # These need to be defined inside the function to ensure Sedona's Geometry UDTs have been registered
@@ -206,6 +206,8 @@ class TestDataframe(TestGeopandasBase):
         assert type(df_copy) is GeoDataFrame
 
     def test_set_geometry(self):
+        from sedona.geopandas.geodataframe import MissingGeometryColumnError
+
         points1 = [Point(x, x) for x in range(3)]
         points2 = [Point(x + 5, x + 5) for x in range(3)]
 
@@ -213,7 +215,7 @@ class TestDataframe(TestGeopandasBase):
         sgpd_df = sgpd.GeoDataFrame(data)
 
         # No geometry column set yet
-        with pytest.raises(AttributeError):
+        with pytest.raises(MissingGeometryColumnError):
             _ = sgpd_df.geometry
 
         # TODO: Try to optimize this with self.ps_allow_diff_frames() away

--- a/python/tests/geopandas/test_geodataframe.py
+++ b/python/tests/geopandas/test_geodataframe.py
@@ -334,28 +334,21 @@ class TestDataframe(TestGeopandasBase):
         square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
 
         data = {"geometry1": [point, square], "id": [1, 2], "value": ["a", "b"]}
-        df = GeoDataFrame(data)
+        df = GeoDataFrame(data, geometry="geometry1")
 
         # Apply buffer with distance 0.5
-        buffer_df = df.buffer(0.5)
+        result = df.buffer(0.5)
 
         # Verify result is a GeoDataFrame
-        assert type(buffer_df) is GeoDataFrame
-
-        # Verify the original columns are preserved
-        assert "geometry1_buffered" in buffer_df.columns
-        assert "id" in buffer_df.columns
-        assert "value" in buffer_df.columns
+        assert type(result) is GeoSeries
 
         # Convert to pandas to extract individual geometries
-        pandas_df = buffer_df._internal.spark_frame.select(
-            "geometry1_buffered"
-        ).toPandas()
+        pd_series = result.to_pandas()
 
         # Calculate areas to verify buffer was applied correctly
         # Point buffer with radius 0.5 should have area approximately π * 0.5² ≈ 0.785
         # Square buffer with radius 0.5 should expand the 1x1 square to 2x2 square with rounded corners
-        areas = [geom.area for geom in pandas_df["geometry1_buffered"]]
+        areas = [geom.area for geom in pd_series]
 
         # Check that square buffer area is greater than original (1.0)
         assert areas[1] > 1.0

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -46,9 +46,13 @@ class TestGeopandasBase(TestBase):
 
     # TODO chore: rename to check_sgpd_series_equals_gpd_series and change the names in the geoseries tests
     @classmethod
-    def check_sgpd_equals_gpd(cls, actual: GeoSeries, expected: gpd.GeoSeries):
-        assert isinstance(actual, GeoSeries), "result is not a sgpd.GeoSeries"
-        assert isinstance(expected, gpd.GeoSeries), "expected is not a gpd.GeoSeries"
+    def check_sgpd_equals_gpd(
+        cls,
+        actual: GeoSeries,
+        expected: gpd.GeoSeries,
+    ):
+        assert isinstance(actual, GeoSeries)
+        assert isinstance(expected, gpd.GeoSeries)
         sgpd_result = actual.to_geopandas()
         assert len(sgpd_result) == len(expected), "results are of different lengths"
         for a, e in zip(sgpd_result, expected):

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -23,6 +23,7 @@ import pandas as pd
 import pyspark.pandas as ps
 from pandas.testing import assert_series_equal
 from contextlib import contextmanager
+from shapely.geometry import GeometryCollection
 from shapely.geometry.base import BaseGeometry
 
 
@@ -97,6 +98,11 @@ class TestGeopandasBase(TestBase):
             yield
         finally:
             ps.reset_option("compute.ops_on_diff_frames")
+
+    def contains_any_geom_collection(self, geoms1, geoms2) -> bool:
+        return any(isinstance(g, GeometryCollection) for g in geoms1) or any(
+            isinstance(g, GeometryCollection) for g in geoms2
+        )
 
     @classmethod
     def check_geom_equals(cls, actual: BaseGeometry, expected: BaseGeometry):

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -47,9 +47,10 @@ class TestGeopandasBase(TestBase):
     # TODO chore: rename to check_sgpd_series_equals_gpd_series and change the names in the geoseries tests
     @classmethod
     def check_sgpd_equals_gpd(cls, actual: GeoSeries, expected: gpd.GeoSeries):
-        assert isinstance(actual, GeoSeries)
-        assert isinstance(expected, gpd.GeoSeries)
+        assert isinstance(actual, GeoSeries), "result is not a sgpd.GeoSeries"
+        assert isinstance(expected, gpd.GeoSeries), "expected is not a gpd.GeoSeries"
         sgpd_result = actual.to_geopandas()
+        assert len(sgpd_result) == len(expected), "results are of different lengths"
         for a, e in zip(sgpd_result, expected):
             if a is None or e is None:
                 assert a is None and e is None
@@ -65,26 +66,38 @@ class TestGeopandasBase(TestBase):
     def check_sgpd_df_equals_gpd_df(
         cls, actual: GeoDataFrame, expected: gpd.GeoDataFrame
     ):
-        assert isinstance(actual, GeoDataFrame)
-        assert isinstance(expected, gpd.GeoDataFrame)
+        assert isinstance(actual, GeoDataFrame), "result is not a sgpd.GeoDataFrame"
+        assert isinstance(
+            expected, gpd.GeoDataFrame
+        ), "expected is not a gpd.GeoDataFrame"
         assert len(actual.columns) == len(expected.columns)
         for col_name in actual.keys():
             actual_series, expected_series = actual[col_name], expected[col_name]
             if isinstance(actual_series, GeoSeries):
-                assert isinstance(actual_series, GeoSeries)
+                assert isinstance(
+                    actual_series, GeoSeries
+                ), f"result[{col_name}] series is not a sgpd.GeoSeries"
                 # original geopandas does not guarantee a GeoSeries will be returned, so convert it here
                 expected_series = gpd.GeoSeries(expected_series)
                 cls.check_sgpd_equals_gpd(actual_series, expected_series)
             else:
-                assert isinstance(actual_series, ps.Series)
-                assert isinstance(expected_series, pd.Series)
+                assert isinstance(
+                    actual_series, ps.Series
+                ), f"result[{col_name}] series is not a ps.Series"
+                assert isinstance(
+                    expected_series, pd.Series
+                ), f"expected[{col_name}] series is not a pd.Series"
                 cls.check_pd_series_equal(actual_series, expected_series)
 
     @classmethod
     def check_pd_series_equal(cls, actual: ps.Series, expected: pd.Series):
-        assert isinstance(actual, ps.Series)
-        assert isinstance(expected, pd.Series)
+        assert isinstance(actual, ps.Series), "result series is not a ps.Series"
+        assert isinstance(expected, pd.Series), "expected series is not a pd.Series"
         assert_series_equal(actual.to_pandas(), expected)
+
+    @classmethod
+    def contains_any_geom_collection(cls, geoms) -> bool:
+        return any(isinstance(g, GeometryCollection) for g in geoms)
 
     @contextmanager
     def ps_allow_diff_frames(self):

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Union
 from tests.test_base import TestBase
 from sedona.geopandas import GeoDataFrame, GeoSeries
 import pyspark.sql
@@ -25,6 +26,7 @@ from pandas.testing import assert_series_equal
 from contextlib import contextmanager
 from shapely.geometry import GeometryCollection
 from shapely.geometry.base import BaseGeometry
+from pandas.testing import assert_index_equal
 
 
 class TestGeopandasBase(TestBase):
@@ -66,6 +68,8 @@ class TestGeopandasBase(TestBase):
                 a, e, tolerance=1e-2
             )  # increased tolerance from 1e-6
 
+        assert_index_equal(actual.index.to_pandas(), expected.index)
+
     @classmethod
     def check_sgpd_df_equals_gpd_df(
         cls, actual: GeoDataFrame, expected: gpd.GeoDataFrame
@@ -98,6 +102,12 @@ class TestGeopandasBase(TestBase):
         assert isinstance(actual, ps.Series), "result series is not a ps.Series"
         assert isinstance(expected, pd.Series), "expected series is not a pd.Series"
         assert_series_equal(actual.to_pandas(), expected)
+
+    @classmethod
+    def check_index_equal(
+        cls, actual: Union[ps.DataFrame, ps.Series], expected: ps.Index
+    ):
+        assert_index_equal(actual.index, expected)
 
     @classmethod
     def contains_any_geom_collection(cls, geoms) -> bool:

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -23,6 +23,7 @@ import pandas as pd
 import pyspark.pandas as ps
 from pandas.testing import assert_series_equal
 from contextlib import contextmanager
+from shapely.geometry.base import BaseGeometry
 
 
 class TestGeopandasBase(TestBase):
@@ -96,3 +97,9 @@ class TestGeopandasBase(TestBase):
             yield
         finally:
             ps.reset_option("compute.ops_on_diff_frames")
+
+    @classmethod
+    def check_geom_equals(cls, actual: BaseGeometry, expected: BaseGeometry):
+        assert isinstance(actual, BaseGeometry)
+        assert isinstance(expected, BaseGeometry)
+        assert actual.equals(expected)

--- a/python/tests/geopandas/test_geopandas_base.py
+++ b/python/tests/geopandas/test_geopandas_base.py
@@ -55,6 +55,7 @@ class TestGeopandasBase(TestBase):
     ):
         assert isinstance(actual, GeoSeries)
         assert isinstance(expected, gpd.GeoSeries)
+        assert actual.name == expected.name, "results are of different names"
         sgpd_result = actual.to_geopandas()
         assert len(sgpd_result) == len(expected), "results are of different lengths"
         for a, e in zip(sgpd_result, expected):

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -180,7 +180,20 @@ class TestGeoSeries(TestGeopandasBase):
         pass
 
     def test_from_arrow(self):
-        pass
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        import pyarrow as pa
+
+        table = pa.table({"a": [0, 1, 2], "b": [0.1, 0.2, 0.3]})
+        with pytest.raises(ValueError, match="No GeoArrow geometry field found"):
+            GeoSeries.from_arrow(table["a"].chunk(0))
+
+        gpd_series = gpd.GeoSeries(
+            [Point(1, 1), Polygon(), LineString([(0, 0), (1, 1)]), None]
+        )
+        result = sgpd.GeoSeries.from_arrow(gpd_series.to_arrow())
+        self.check_sgpd_equals_gpd(result, gpd_series)
 
     def test_to_file(self):
         pass
@@ -349,7 +362,34 @@ class TestGeoSeries(TestGeopandasBase):
             sgpd.GeoSeries([Polygon([(0, 90), (1, 90), (2, 90)])]).estimate_utm_crs()
 
     def test_to_json(self):
-        pass
+        s = GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+
+        # TODO: optimize this away
+        with self.ps_allow_diff_frames():
+            result = s.to_json()
+        expected = '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "pr\
+operties": {}, "geometry": {"type": "Point", "coordinates": [1.0, 1.0]}, "bbox": [1.0,\
+ 1.0, 1.0, 1.0]}, {"id": "1", "type": "Feature", "properties": {}, "geometry": {"type"\
+: "Point", "coordinates": [2.0, 2.0]}, "bbox": [2.0, 2.0, 2.0, 2.0]}, {"id": "2", "typ\
+e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3.0, 3.\
+0]}, "bbox": [3.0, 3.0, 3.0, 3.0]}], "bbox": [1.0, 1.0, 3.0, 3.0]}'
+
+        assert result == expected
+
+        with self.ps_allow_diff_frames():
+            result = s.to_json(show_bbox=True)
+            expected = '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [1.0, 1.0]}, "bbox": [1.0, 1.0, 1.0, 1.0]}, {"id": "1", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [2.0, 2.0]}, "bbox": [2.0, 2.0, 2.0, 2.0]}, {"id": "2", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3.0, 3.0]}, "bbox": [3.0, 3.0, 3.0, 3.0]}], "bbox": [1.0, 1.0, 3.0, 3.0]}'
+            assert result == expected
+
+        with self.ps_allow_diff_frames():
+            result = s.to_json(drop_id=True)
+            expected = '{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [1.0, 1.0]}, "bbox": [1.0, 1.0, 1.0, 1.0]}, {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [2.0, 2.0]}, "bbox": [2.0, 2.0, 2.0, 2.0]}, {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3.0, 3.0]}, "bbox": [3.0, 3.0, 3.0, 3.0]}], "bbox": [1.0, 1.0, 3.0, 3.0]}'
+            assert result == expected
+
+        with self.ps_allow_diff_frames():
+            result = s.set_crs("EPSG:3857").to_json(to_wgs84=True)
+            expected = '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [8.983152841195214e-06, 8.983152841195177e-06]}, "bbox": [8.983152841195214e-06, 8.983152841195177e-06, 8.983152841195214e-06, 8.983152841195177e-06]}, {"id": "1", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [1.7966305682390428e-05, 1.7966305682390134e-05]}, "bbox": [1.7966305682390428e-05, 1.7966305682390134e-05, 1.7966305682390428e-05, 1.7966305682390134e-05]}, {"id": "2", "type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [2.6949458523585642e-05, 2.694945852358465e-05]}, "bbox": [2.6949458523585642e-05, 2.694945852358465e-05, 2.6949458523585642e-05, 2.694945852358465e-05]}], "bbox": [8.983152841195214e-06, 8.983152841195177e-06, 2.6949458523585642e-05, 2.694945852358465e-05]}'
+            assert result == expected
 
     def test_to_wkb(self):
         if parse_version(shapely.__version__) < parse_version("2.0.0"):
@@ -421,7 +461,24 @@ class TestGeoSeries(TestGeopandasBase):
         self.check_pd_series_equal(result, expected)
 
     def test_to_arrow(self):
-        pass
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        import pyarrow as pa
+
+        gser = GeoSeries([Point(1, 2), Point(2, 1)])
+        # TODO: optimize this away
+        with self.ps_allow_diff_frames():
+            arrow_array = gser.to_arrow()
+        result = pa.array(arrow_array)
+
+        expected = [
+            "0101000000000000000000F03F0000000000000040",
+            "01010000000000000000000040000000000000F03F",
+        ]
+        expected = pa.array([bytes.fromhex(x) for x in expected], type=pa.binary())
+
+        assert result.equals(expected)
 
     def test_clip(self):
         pass

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -1341,3 +1341,10 @@ class TestGeoSeries(TestGeopandasBase):
 
         geo_series = sgpd.GeoSeries(self.geoseries, crs=4326)
         assert geo_series.crs.to_epsg() == 4326
+
+        # This test errors due to a bug in pyspark.
+        # We can uncomment it once the fix is https://github.com/apache/spark/pull/51475 is merged
+        # It was tested locally by using the fixed version of pyspark
+        # # First element null
+        # geo_series = sgpd.GeoSeries([None, None, Point(1, 1)], crs=4326)
+        # assert geo_series.crs.to_epsg() == 4326

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 import pandas as pd
 import geopandas as gpd
+import pyspark.pandas as ps
 import sedona.geopandas as sgpd
 from sedona.geopandas import GeoSeries
 from tests.geopandas.test_geopandas_base import TestGeopandasBase
@@ -64,6 +65,18 @@ class TestGeoSeries(TestGeopandasBase):
     def test_empty_list(self):
         s = sgpd.GeoSeries([])
         assert s.count() == 0
+
+    def test_non_geom_fails(self):
+        with pytest.raises(TypeError):
+            GeoSeries([0, 1, 2])
+        with pytest.raises(TypeError):
+            GeoSeries([0, 1, 2], crs="epsg:4326")
+        with pytest.raises(TypeError):
+            GeoSeries(["a", "b", "c"])
+        with pytest.raises(TypeError):
+            GeoSeries(pd.Series([0, 1, 2]), crs="epsg:4326")
+        with pytest.raises(TypeError):
+            GeoSeries(ps.Series([0, 1, 2]))
 
     def test_area(self):
         result = self.geoseries.area.to_pandas()

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -793,6 +793,41 @@ class TestGeoSeries(TestGeopandasBase):
         expected = GeometryCollection()
         self.check_geom_equals(result, expected)
 
+    def test_crosses(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                LineString([(0, 0), (2, 2)]),
+                LineString([(2, 0), (0, 2)]),
+                Point(0, 1),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                LineString([(1, 0), (1, 3)]),
+                LineString([(2, 0), (0, 2)]),
+                Point(1, 1),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+
+        line = LineString([(-1, 1), (3, 1)])
+        result = s.crosses(line)
+        expected = pd.Series([True, True, True, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.crosses(s2, align=True)
+        expected = pd.Series([False, True, False, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.crosses(s2, align=False)
+        expected = pd.Series([True, True, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_disjoint(self):
+        pass
+
     def test_intersects(self):
         s = sgpd.GeoSeries(
             [
@@ -836,6 +871,208 @@ class TestGeoSeries(TestGeopandasBase):
 
         result = s.intersects(s2, align=False)
         expected = pd.Series([True, True, True, True])
+
+    def test_overlaps(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                LineString([(0, 0), (2, 2)]),
+                MultiPoint([(0, 0), (0, 1)]),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 0), (0, 2)]),
+                LineString([(0, 1), (1, 1)]),
+                LineString([(1, 1), (3, 3)]),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+
+        polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        result = s.overlaps(polygon)
+        expected = pd.Series([True, True, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.overlaps(s2, align=True)
+        expected = pd.Series([False, True, False, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.overlaps(s2, align=False)
+        expected = pd.Series([True, False, True, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_touches(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                LineString([(0, 0), (2, 2)]),
+                MultiPoint([(0, 0), (0, 1)]),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0, 0), (-2, 0), (0, -2)]),
+                LineString([(0, 1), (1, 1)]),
+                LineString([(1, 1), (3, 0)]),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+        line = LineString([(0, 0), (-1, -2)])
+        result = s.touches(line)
+        expected = pd.Series([True, True, True, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.touches(s2, align=True)
+        expected = pd.Series([False, True, True, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.touches(s2, align=False)
+        expected = pd.Series([True, False, True, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_within(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (1, 2), (0, 2)]),
+                LineString([(0, 0), (0, 2)]),
+                Point(0, 1),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0, 0), (1, 1), (0, 1)]),
+                LineString([(0, 0), (0, 2)]),
+                LineString([(0, 0), (0, 1)]),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+
+        polygon = Polygon([(0, 0), (2, 2), (0, 2)])
+        result = s.within(polygon)
+        expected = pd.Series([True, True, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s2.within(s, align=True)
+        expected = pd.Series([False, False, True, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s2.within(s, align=False)
+        expected = pd.Series([True, False, True, True], index=range(1, 5))
+        assert_series_equal(result.to_pandas(), expected)
+
+        # Ensure we return False if either geometries are empty
+        s = GeoSeries([Point(), Point(), Polygon(), Point(0, 1)])
+        result = s.within(s2, align=False)
+        expected = pd.Series([False, False, False, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_covers(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                LineString([(0, 0), (2, 2)]),
+                Point(0, 0),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                LineString([(1, 1), (1.5, 1.5)]),
+                Point(0, 0),
+            ],
+            index=range(1, 5),
+        )
+
+        poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        result = s.covers(poly)
+        expected = pd.Series([True, False, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.covers(s2, align=True)
+        expected = pd.Series([False, False, False, False, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.covers(s2, align=False)
+        expected = pd.Series([True, False, True, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+        # Ensure we return False if either geometries are empty
+        s = GeoSeries([Point(), Point(), Polygon(), Point(0, 0)])
+        result = s.covers(s2, align=False)
+        expected = pd.Series([False, False, False, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_covered_by(self):
+        s = GeoSeries(
+            [
+                Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                LineString([(1, 1), (1.5, 1.5)]),
+                Point(0, 0),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                LineString([(0, 0), (2, 2)]),
+                Point(0, 0),
+            ],
+            index=range(1, 5),
+        )
+
+        poly = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+        result = s.covered_by(poly)
+        expected = pd.Series([True, True, True, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.covered_by(s2, align=True)
+        expected = pd.Series([False, True, True, True, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.covered_by(s2, align=False)
+        expected = pd.Series([True, False, True, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+    def test_distance(self):
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (1, 0), (1, 1)]),
+                Polygon([(0, 0), (-1, 0), (-1, 1)]),
+                LineString([(1, 1), (0, 0)]),
+                Point(0, 0),
+            ],
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]),
+                Point(3, 1),
+                LineString([(1, 0), (2, 0)]),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+        point = Point(-1, 0)
+        result = s.distance(point)
+        expected = pd.Series([1.0, 0.0, 1.0, 1.0])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.distance(s2, align=True)
+        expected = pd.Series([np.nan, 0.707107, 2.000000, 1.000000, np.nan])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s.distance(s2, align=False)
+        expected = pd.Series([0.000000, 3.162278, 0.707107, 1.000000])
+        assert_series_equal(result.to_pandas(), expected)
 
     def test_intersection(self):
         import pyspark.pandas as ps
@@ -946,7 +1183,37 @@ class TestGeoSeries(TestGeopandasBase):
         pass
 
     def test_contains(self):
-        pass
+        s = GeoSeries(
+            [
+                Polygon([(0, 0), (1, 1), (0, 1)]),
+                LineString([(0, 0), (0, 2)]),
+                LineString([(0, 0), (0, 1)]),
+                Point(0, 1),
+            ],
+            index=range(0, 4),
+        )
+        s2 = GeoSeries(
+            [
+                Polygon([(0, 0), (2, 2), (0, 2)]),
+                Polygon([(0, 0), (1, 2), (0, 2)]),
+                LineString([(0, 0), (0, 2)]),
+                Point(0, 1),
+            ],
+            index=range(1, 5),
+        )
+
+        point = Point(0, 1)
+        result = s.contains(point)
+        expected = pd.Series([False, True, False, True])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s2.contains(s, align=True)
+        expected = pd.Series([False, False, False, True, False])
+        assert_series_equal(result.to_pandas(), expected)
+
+        result = s2.contains(s, align=False)
+        expected = pd.Series([True, False, True, True], index=range(1, 5))
+        assert_series_equal(result.to_pandas(), expected)
 
     def test_contains_properly(self):
         pass

--- a/python/tests/geopandas/test_geoseries.py
+++ b/python/tests/geopandas/test_geoseries.py
@@ -33,6 +33,7 @@ from shapely.geometry import (
     MultiLineString,
     MultiPolygon,
     LinearRing,
+    box,
 )
 from pandas.testing import assert_series_equal
 import pytest
@@ -781,7 +782,16 @@ class TestGeoSeries(TestGeopandasBase):
         pass
 
     def test_union_all(self):
-        pass
+        s = GeoSeries([box(0, 0, 1, 1), box(0, 0, 2, 2)])
+        result = s.union_all()
+        expected = Polygon([(0, 1), (0, 2), (2, 2), (2, 0), (1, 0), (0, 0), (0, 1)])
+        self.check_geom_equals(result, expected)
+
+        # Empty GeoSeries
+        s = sgpd.GeoSeries([])
+        result = s.union_all()
+        expected = GeometryCollection()
+        self.check_geom_equals(result, expected)
 
     def test_intersects(self):
         s = sgpd.GeoSeries(

--- a/python/tests/geopandas/test_io.py
+++ b/python/tests/geopandas/test_io.py
@@ -1,0 +1,245 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import tempfile
+import pytest
+import shapely
+import pandas as pd
+import geopandas as gpd
+import pyspark.pandas as ps
+from functools import partial
+from sedona.geopandas import GeoDataFrame, GeoSeries, read_file
+from tests import tests_resource
+from tests.geopandas.test_geopandas_base import TestGeopandasBase
+from shapely.geometry import (
+    Point,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    LineString,
+    MultiPolygon,
+    GeometryCollection,
+    LinearRing,
+)
+from packaging.version import parse as parse_version
+
+TEST_DATA_DIR = os.path.join("..", "spark", "common", "src", "test", "resources")
+
+
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
+class TestIO(TestGeopandasBase):
+    def setup_method(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    #########################################################
+    # File reading tests
+    #########################################################
+
+    # Modified version of Sedona's test_shapefile.py test_read_simple
+    @pytest.mark.parametrize(
+        "read_func",
+        [
+            partial(GeoDataFrame.from_file, format="shapefile"),
+            partial(read_file, format="Shapefile"),
+        ],
+    )
+    def test_read_shapefile(self, read_func):
+        data_dir = os.path.join(tests_resource, "shapefiles/polygon")
+
+        df = read_func(data_dir)
+
+        assert df.count().item() == 10000
+
+        subset_df = GeoDataFrame(df.head(100))
+        # assert only one column
+        assert subset_df.shape[1] == 1
+
+        # assert all geometries are polygons or multipolygons
+        assert subset_df["geometry"].geom_type.isin(["Polygon", "MultiPolygon"]).all()
+
+        # Check inference and single file works
+        data_file = os.path.join(data_dir, "map.shp")
+        df = read_func(data_file)
+
+        assert df.count().item() == 10000
+
+    @pytest.mark.parametrize(
+        "read_func",
+        [
+            partial(GeoDataFrame.from_file, format="geojson"),
+            partial(read_file, format="GeoJSON"),
+        ],
+    )
+    def test_read_geojson(self, read_func):
+        datafile = os.path.join(TEST_DATA_DIR, "geojson/test1.json")
+        df = read_func(datafile)
+        assert (df.count() == 1).all()
+
+        # Check that inference works
+        df = read_func(datafile)
+        assert (df.count() == 1).all()
+
+    @pytest.mark.parametrize(
+        "read_func",
+        [
+            partial(GeoDataFrame.from_file, format="geoparquet"),
+            partial(read_file, format="GeoParquet"),
+        ],
+    )
+    def test_read_geoparquet(self, read_func):
+        input_location = os.path.join(TEST_DATA_DIR, "geoparquet/example1.parquet")
+        df = read_func(input_location)
+        # check that all column counts are 5
+        assert (df.count() == 5).all()
+
+        # Check that inference works
+        df = read_func(input_location)
+        assert (df.count() == 5).all()
+
+    # From Sedona's GeoPackageReaderTest.scala
+    @pytest.mark.parametrize(
+        "read_func",
+        [
+            partial(GeoDataFrame.from_file, format="geopackage"),
+            partial(read_file, format="GeoPackage"),
+        ],
+    )
+    def test_read_geopackage(self, read_func):
+        datafile = os.path.join(TEST_DATA_DIR, "geopackage/features.gpkg")
+
+        table_name = "GB_Hex_5km_GS_CompressibleGround_v8"
+        expected_cnt = 4233
+        df = read_func(datafile, table_name=table_name)
+        assert df["geom"].count() == expected_cnt
+
+        # Ensure inference works
+        table_name = "GB_Hex_5km_GS_Landslides_v8"
+        expected_cnt = 4228
+        df = read_func(datafile, table_name=table_name)
+        assert df["geom"].count() == expected_cnt
+
+    #########################################################
+    # File writing tests
+    #########################################################
+
+    def _get_next_temp_file_path(self, ext: str):
+        temp_file_path = os.path.join(
+            self.tempdir, next(tempfile._get_candidate_names()) + "." + ext
+        )
+        return temp_file_path
+
+    @pytest.mark.parametrize(
+        "write_func",
+        [
+            partial(GeoDataFrame.to_file, driver="GeoParquet"),
+            partial(GeoDataFrame.to_file, driver="geoparquet"),
+            GeoDataFrame.to_parquet,
+        ],
+    )
+    def test_to_geoparquet(self, write_func):
+        sgpd_df = GeoDataFrame(
+            {"geometry": [Point(0, 0), LineString([(0, 0), (1, 1)])], "int": [1, 2]}
+        )
+
+        temp_file_path = self._get_next_temp_file_path("parquet")
+
+        self._apply_func(sgpd_df, write_func, temp_file_path)
+
+        # Ensure reading from geopandas creates the same resulting GeoDataFrame
+        gpd_df = gpd.read_parquet(temp_file_path)
+        self.check_sgpd_df_equals_gpd_df(sgpd_df, gpd_df)
+
+    @pytest.mark.parametrize(
+        "write_func",
+        [
+            partial(GeoDataFrame.to_file, driver="geojson"),  # index=None here is False
+            partial(GeoDataFrame.to_file, driver="GeoJSON", index=True),
+            partial(GeoDataFrame.to_file, driver="geojson", index=True),
+        ],
+    )
+    def test_to_geojson(self, write_func):
+        sgpd_df = GeoDataFrame(
+            {"geometry": [Point(0, 0), LineString([(0, 0), (1, 1)])], "int": [1, 2]},
+            index=[1, 2],
+        )
+        temp_file_path = self._get_next_temp_file_path("json")
+        self._apply_func(sgpd_df, write_func, temp_file_path)
+
+        read_result = GeoDataFrame.from_file(
+            temp_file_path, format="geojson"
+        ).to_geopandas()
+
+        # if index was true, the contents should be in the same order as the original GeoDataFrame
+        if write_func.keywords.get("index", None) == True:
+            self.check_sgpd_df_equals_gpd_df(sgpd_df, read_result)
+        else:
+            # if index was not kept, just check we have all rows and we have default index
+            self.check_index_equal(read_result, pd.Index([0, 1]))
+
+    @pytest.mark.parametrize(
+        "write_func",
+        [
+            partial(GeoDataFrame.to_file, driver="geojson"),
+        ],
+    )
+    def test_to_file_non_int_index(self, write_func):
+        sgpd_df = GeoDataFrame(
+            {"geometry": [Point(0, 0), LineString([(0, 0), (1, 1)])], "int": [1, 2]},
+            index=["a", "b"],
+        )
+        temp_file_path = self._get_next_temp_file_path("json")
+        self._apply_func(sgpd_df, write_func, temp_file_path)
+
+        read_result = GeoDataFrame.from_file(
+            temp_file_path, format="geojson"
+        ).to_geopandas()
+
+        # Since index was of non-int dtype, index=None here is True
+        self.check_sgpd_df_equals_gpd_df(sgpd_df, read_result)
+
+    @pytest.mark.parametrize(
+        "format",
+        [
+            "geojson",
+            "geoparquet",
+        ],
+    )
+    def test_to_file_and_from_file_series(self, format):
+        sgpd_ser = GeoSeries([Point(0, 0), LineString([(0, 0), (1, 1)])])
+        ext = format.replace("geo", "")
+        temp_file_path = self._get_next_temp_file_path(ext)
+
+        sgpd_ser.to_file(temp_file_path, driver=format, index=True)
+
+        read_result = GeoSeries.from_file(temp_file_path, format=format)
+        read_result = read_result.to_geopandas()
+
+        # Since index=True, the contents should be in the same order as the original GeoSeries
+        self.check_sgpd_equals_gpd(sgpd_ser, read_result)
+
+    def _apply_func(self, obj, func, *args):
+        """
+        Helper function to conditionally apply functions or methods to an object correctly.
+        """
+        if type(func) == str:
+            return getattr(obj, func)(*args)
+        else:
+            return func(obj, *args)

--- a/python/tests/geopandas/test_io.py
+++ b/python/tests/geopandas/test_io.py
@@ -232,6 +232,9 @@ class TestIO(TestGeopandasBase):
         read_result = GeoSeries.from_file(temp_file_path, format=format)
         read_result = read_result.to_geopandas()
 
+        # In Geopandas, the name of the series is always read in to be "geometry"
+        sgpd_ser.name = "geometry"
+
         # Since index=True, the contents should be in the same order as the original GeoSeries
         self.check_sgpd_equals_gpd(sgpd_ser, read_result)
 

--- a/python/tests/geopandas/test_match_geopandas_dataframe.py
+++ b/python/tests/geopandas/test_match_geopandas_dataframe.py
@@ -18,6 +18,7 @@
 import pytest
 import shutil
 import tempfile
+import shapely
 from shapely.geometry import (
     Point,
     Polygon,
@@ -36,6 +37,10 @@ from tests.geopandas.test_geopandas_base import TestGeopandasBase
 import pyspark.pandas as ps
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestMatchGeopandasDataFrame(TestGeopandasBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -41,6 +41,10 @@ import pyspark.pandas as ps
 from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestMatchGeopandasSeries(TestGeopandasBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()
@@ -323,7 +327,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             gpd_result = gpd.GeoSeries(geom).fillna()
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
-        data = [None, None, None, None, Point(0, 1)]
+        data = [Point(1, 1), None, None, None, Point(0, 1)]
         sgpd_result = GeoSeries(data).fillna()
         gpd_result = gpd.GeoSeries(data).fillna()
         self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
@@ -479,8 +483,9 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             LineString([(0, 0), (0, 0)]),
             LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
             LineString([(0, 0), (1, 1), (0, 0)]),
-            LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
-            LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
+            # Errors for LinearRing: issue #2120
+            # LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
+            # LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
         ]
         sgpd_result = GeoSeries(data).is_simple
         gpd_result = gpd.GeoSeries(data).is_simple

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -128,18 +128,6 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             assert isinstance(gpd_series, gpd.GeoSeries)
             assert isinstance(gpd_series.geometry, gpd.GeoSeries)
 
-    def test_non_geom_fails(self):
-        with pytest.raises(TypeError):
-            GeoSeries([0, 1, 2])
-        with pytest.raises(TypeError):
-            GeoSeries([0, 1, 2], crs="epsg:4326")
-        with pytest.raises(TypeError):
-            GeoSeries(["a", "b", "c"])
-        with pytest.raises(TypeError):
-            GeoSeries(pd.Series([0, 1, 2]), crs="epsg:4326")
-        with pytest.raises(TypeError):
-            GeoSeries(ps.Series([0, 1, 2]))
-
     def test_to_geopandas(self):
         for _, geom in self.geoms:
             sgpd_result = GeoSeries(geom)

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -282,7 +282,15 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_from_arrow(self):
-        pass
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        for _, geom in self.geoms:
+            gpd_series = gpd.GeoSeries(geom)
+            gpd_result = gpd.GeoSeries.from_arrow(gpd_series.to_arrow())
+
+            sgpd_result = GeoSeries.from_arrow(gpd_series.to_arrow())
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_to_file(self):
         pass
@@ -371,7 +379,10 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
                 assert sgpd_result == gpd_result
 
     def test_to_json(self):
-        pass
+        for _, geom in self.geoms:
+            sgpd_result = GeoSeries(geom).to_json()
+            gpd_result = gpd.GeoSeries(geom).to_json()
+            assert sgpd_result == gpd_result
 
     def test_to_wkb(self):
         for _, geom in self.geoms:
@@ -395,7 +406,15 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_to_arrow(self):
-        pass
+        if parse_version(gpd.__version__) < parse_version("1.0.0"):
+            return
+
+        import pyarrow as pa
+
+        for _, geom in self.geoms:
+            sgpd_result = pa.array(GeoSeries(geom).to_arrow())
+            gpd_result = pa.array(gpd.GeoSeries(geom).to_arrow())
+            assert sgpd_result == gpd_result
 
     def test_clip(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -62,6 +62,11 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         self.linestrings = [LineString([(x, x + 1), (x + 2, x + 3)]) for x in range(3)]
 
+        self.linearrings = [
+            LinearRing([(x, x), (x + 1, x), (x + 1, x + 1), (x, x + 1), (x, x)])
+            for x in range(3)
+        ]
+
         self.multilinestrings = [
             MultiLineString(
                 [[[x, x + 1], [x + 2, x + 3]], [[x + 4, x + 5], [x + 6, x + 7]]]
@@ -101,35 +106,35 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             )
         ]
 
-        # (sql_table_name, geom)
         self.geoms = [
-            ("points", self.points),
-            ("multipoints", self.multipoints),
-            ("linestrings", self.linestrings),
-            ("multilinestrings", self.multilinestrings),
-            ("polygons", self.polygons),
-            ("multipolygons", self.multipolygons),
-            ("geomcollection", self.geomcollection),
+            self.points,
+            self.multipoints,
+            self.linestrings,
+            self.linearrings,
+            self.multilinestrings,
+            self.polygons,
+            self.multipolygons,
+            self.geomcollection,
         ]
 
-        # create the tables in sedona spark
-        for i, (table_name, geoms) in enumerate(self.geoms):
-            wkt_string = [g.wkt for g in geoms]
-            pd_df = pd.DataFrame({"id": i, "geometry": wkt_string})
-            spark_df = self.spark.createDataFrame(pd_df)
-            spark_df.createOrReplaceTempView(table_name)
+        self.pairs = [
+            (self.points, self.multipolygons),
+            (self.geomcollection, self.polygons),
+            (self.linestrings, self.multipoints),
+            (self.linearrings, self.multilinestrings),
+        ]
 
     def teardown_method(self):
         shutil.rmtree(self.tempdir)
 
     def test_constructor(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             gpd_series = gpd.GeoSeries(geom)
             assert isinstance(gpd_series, gpd.GeoSeries)
             assert isinstance(gpd_series.geometry, gpd.GeoSeries)
 
     def test_to_geopandas(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom)
             gpd_result = gpd.GeoSeries(geom)
             # The below method calls to_geopandas() on sgpd_result, so we don't do it here
@@ -178,7 +183,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         assert type(area) is ps.Series
         assert area.count() == 2
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).area
             gpd_result = gpd.GeoSeries(geom).area
             self.check_pd_series_equal(sgpd_result, gpd_result)
@@ -189,7 +194,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         assert type(buffer) is GeoSeries
         assert buffer.count() == 2
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             dist = 0.2
             sgpd_result = GeoSeries(geom).buffer(dist)
             gpd_result = gpd.GeoSeries(geom).buffer(dist)
@@ -210,7 +215,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         assert os.path.exists(temp_file_path)
 
     def test_geometry(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             gpd_result = gpd.GeoSeries(geom).geometry
             sgpd_result = GeoSeries(geom).geometry
             assert isinstance(sgpd_result, GeoSeries)
@@ -244,14 +249,14 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_from_wkb(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             wkb = [g.wkb for g in geom]
             sgpd_result = GeoSeries.from_wkb(wkb)
             gpd_result = gpd.GeoSeries.from_wkb(wkb)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_from_wkt(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             wkt = [g.wkt for g in geom]
             sgpd_result = GeoSeries.from_wkt(wkt)
             gpd_result = gpd.GeoSeries.from_wkt(wkt)
@@ -285,7 +290,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         if parse_version(gpd.__version__) < parse_version("1.0.0"):
             return
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             gpd_series = gpd.GeoSeries(geom)
             gpd_result = gpd.GeoSeries.from_arrow(gpd_series.to_arrow())
 
@@ -297,7 +302,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
     @pytest.mark.parametrize("fun", ["isna", "isnull"])
     def test_isna(self, fun):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = getattr(GeoSeries(geom), fun)()
             assert isinstance(sgpd_result, ps.Series)
             gpd_result = getattr(gpd.GeoSeries(geom), fun)()
@@ -305,7 +310,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
     @pytest.mark.parametrize("fun", ["notna", "notnull"])
     def test_notna(self, fun):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = getattr(GeoSeries(geom), fun)()
             assert isinstance(sgpd_result, ps.Series)
             gpd_result = getattr(gpd.GeoSeries(geom), fun)()
@@ -318,7 +323,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_fillna(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).fillna()
             gpd_result = gpd.GeoSeries(geom).fillna()
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
@@ -346,17 +351,13 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_to_crs(self):
-        for _, geom in self.geoms:
-            sgpd_result = GeoSeries(geom, crs=4326)
-            gpd_result = gpd.GeoSeries(geom, crs=4326)
-            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
-
-            sgpd_result = sgpd_result.to_crs(epsg=3857)
-            gpd_result = gpd_result.to_crs(epsg=3857)
+        for geom in self.geoms:
+            sgpd_result = GeoSeries(geom, crs=4326).to_crs(epsg=3857)
+            gpd_result = gpd.GeoSeries(geom, crs=4326).to_crs(epsg=3857)
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_bounds(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).bounds
             gpd_result = gpd.GeoSeries(geom).bounds
             pd.testing.assert_frame_equal(
@@ -366,26 +367,29 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
     def test_total_bounds(self):
         import numpy as np
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).total_bounds
             gpd_result = gpd.GeoSeries(geom).total_bounds
             np.testing.assert_array_equal(sgpd_result, gpd_result)
 
     def test_estimate_utm_crs(self):
         for crs in ["epsg:4326", "epsg:3857"]:
-            for _, geom in self.geoms:
+            for geom in self.geoms:
                 gpd_result = gpd.GeoSeries(geom, crs=crs).estimate_utm_crs()
                 sgpd_result = GeoSeries(geom, crs=crs).estimate_utm_crs()
                 assert sgpd_result == gpd_result
 
     def test_to_json(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
+            # Sedona converts it to LineString, so the outputs will be different
+            if isinstance(geom[0], LinearRing):
+                continue
             sgpd_result = GeoSeries(geom).to_json()
             gpd_result = gpd.GeoSeries(geom).to_json()
             assert sgpd_result == gpd_result
 
     def test_to_wkb(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).to_wkb()
             gpd_result = gpd.GeoSeries(geom).to_wkb()
             self.check_pd_series_equal(sgpd_result, gpd_result)
@@ -395,7 +399,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_to_wkt(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             ps_series = GeoSeries(geom).to_wkt()
             pd_series = gpd.GeoSeries(geom).to_wkt()
             # There are slight variations of valid wkt (e.g valid parentheses being optional),
@@ -411,7 +415,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         import pyarrow as pa
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = pa.array(GeoSeries(geom).to_arrow())
             gpd_result = pa.array(gpd.GeoSeries(geom).to_arrow())
             assert sgpd_result == gpd_result
@@ -420,7 +424,10 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_geom_type(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
+            # Sedona converts it to LineString, so the outputs will be different
+            if isinstance(geom[0], LinearRing):
+                continue
             sgpd_result = GeoSeries(geom).geom_type
             gpd_result = gpd.GeoSeries(geom).geom_type
             self.check_pd_series_equal(sgpd_result, gpd_result)
@@ -429,14 +436,14 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_length(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).length
             assert isinstance(sgpd_result, ps.Series)
             gpd_result = gpd.GeoSeries(geom).length
             self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_is_valid(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).is_valid
             assert isinstance(sgpd_result, ps.Series)
             gpd_result = gpd.GeoSeries(geom).is_valid
@@ -470,7 +477,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
                 raise ValueError(f"Unexpected result: {a} not equivalent to {e}")
 
     def test_is_empty(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).is_empty
             assert isinstance(sgpd_result, ps.Series)
             gpd_result = gpd.GeoSeries(geom).is_empty
@@ -489,59 +496,53 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         if parse_version(gpd.__version__) < parse_version("1.0.0"):
             pytest.skip("geopandas < 1.0.0 does not support dwithin")
 
-        for i, (_, geom) in enumerate(self.geoms):
-            for _, geom2 in self.geoms[i:]:
-                sgpd_result = GeoSeries(geom).dwithin(GeoSeries(geom2), distance=1)
+        for geom, geom2 in self.pairs:
+            sgpd_result = GeoSeries(geom).dwithin(GeoSeries(geom2), distance=1)
+            gpd_result = gpd.GeoSeries(geom).dwithin(gpd.GeoSeries(geom2), distance=1)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).dwithin(
+                    GeoSeries(geom2), distance=1, align=False
+                )
                 gpd_result = gpd.GeoSeries(geom).dwithin(
-                    gpd.GeoSeries(geom2), distance=1
+                    gpd.GeoSeries(geom2), distance=1, align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
 
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).dwithin(
-                        GeoSeries(geom2), distance=1, align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).dwithin(
-                        gpd.GeoSeries(geom2), distance=1, align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
-
     def test_difference(self):
-        for i, (_, geom) in enumerate(self.geoms):
-            for _, geom2 in self.geoms[i:]:
-                # Sedona doesn't support difference for GeometryCollections
-                if isinstance(geom[0], GeometryCollection) or isinstance(
-                    geom2[0], GeometryCollection
-                ):
-                    continue
-                # Operation doesn't work on invalid geometries
-                if (
-                    not gpd.GeoSeries(geom).is_valid.all()
-                    or not gpd.GeoSeries(geom2).is_valid.all()
-                ):
-                    continue
+        for geom, geom2 in self.pairs:
+            # Sedona doesn't support difference for GeometryCollections
+            if isinstance(geom[0], GeometryCollection) or isinstance(
+                geom2[0], GeometryCollection
+            ):
+                continue
+            # Operation doesn't work on invalid geometries
+            if (
+                not gpd.GeoSeries(geom).is_valid.all()
+                or not gpd.GeoSeries(geom2).is_valid.all()
+            ):
+                continue
 
-                sgpd_result = GeoSeries(geom).difference(GeoSeries(geom2))
-                gpd_result = gpd.GeoSeries(geom).difference(gpd.GeoSeries(geom2))
+            sgpd_result = GeoSeries(geom).difference(GeoSeries(geom2))
+            gpd_result = gpd.GeoSeries(geom).difference(gpd.GeoSeries(geom2))
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).difference(GeoSeries(geom2), align=False)
+                gpd_result = gpd.GeoSeries(geom).difference(
+                    gpd.GeoSeries(geom2), align=False
+                )
                 self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).difference(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).difference(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
-
     def test_is_simple(self):
+        # 'is_simple' is meaningful only for `LineStrings` and `LinearRings`
         data = [
             LineString([(0, 0), (0, 0)]),
             LineString([(0, 0), (1, 1), (1, -1), (0, 1)]),
             LineString([(0, 0), (1, 1), (0, 0)]),
-            # Errors for LinearRing: issue #2120
-            # LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
-            # LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
+            LinearRing([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]),
+            LinearRing([(0, 0), (-1, 1), (-1, -1), (1, -1)]),
         ]
         sgpd_result = GeoSeries(data).is_simple
         gpd_result = gpd.GeoSeries(data).is_simple
@@ -557,7 +558,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_has_z(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).has_z
             gpd_result = gpd.GeoSeries(geom).has_z
             self.check_pd_series_equal(sgpd_result, gpd_result)
@@ -569,7 +570,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         if parse_version(gpd.__version__) < parse_version("1.0.0"):
             pytest.skip("geopandas get_geometry requires version 1.0.0 or higher")
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             # test negative index, in-bounds index, and out of bounds index
             for index in [-1, 0, len(geom) + 1]:
                 sgpd_result = GeoSeries(geom).get_geometry(index)
@@ -584,7 +585,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_boundary(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             # Shapely < 2.0 doesn't support GeometryCollection for boundary operation
             if shapely.__version__ < "2.0.0" and isinstance(
                 geom[0], GeometryCollection
@@ -595,7 +596,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_centroid(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).centroid
             gpd_result = gpd.GeoSeries(geom).centroid
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
@@ -613,7 +614,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_envelope(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).envelope
             gpd_result = gpd.GeoSeries(geom).envelope
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
@@ -661,12 +662,12 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         if shapely.__version__ < "2.1.0":
             pytest.skip("geopandas make_valid requires shapely >= 2.1.0")
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).make_valid(method="structure")
             gpd_result = gpd.GeoSeries(geom).make_valid(method="structure")
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_result = GeoSeries(geom).make_valid(
                 method="structure", keep_collapsed=False
             )
@@ -708,7 +709,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         # Union all the valid geometries
         # Neither our nor geopandas' implementation supports invalid geometries
-        lst = [g for _, geom in self.geoms for g in geom if g.is_valid]
+        lst = [g for geom in self.geoms for g in geom if g.is_valid]
         sgpd_result = GeoSeries(lst).union_all()
         gpd_result = gpd.GeoSeries(lst).union_all()
         self.check_geom_equals(sgpd_result, gpd_result)
@@ -719,45 +720,39 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         self.check_geom_equals(sgpd_result, gpd_result)
 
     def test_crosses(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if self.contains_any_geom_collection(geom, geom2):
-                    continue
+        for geom, geom2 in self.pairs:
+            if self.contains_any_geom_collection(geom, geom2):
+                continue
 
-                # We explicitly specify align=True to quite warnings in geopandas, despite it being the default
+            # We explicitly specify align=True to quite warnings in geopandas, despite it being the default
+            gpd_result = gpd.GeoSeries(geom).crosses(gpd.GeoSeries(geom2), align=True)
+            sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).crosses(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
-                sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=True)
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=False)
-                    gpd_result = gpd.GeoSeries(geom).crosses(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_disjoint(self):
         pass
 
     def test_intersects(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                sgpd_result = GeoSeries(geom).intersects(GeoSeries(geom2), align=True)
+        for geom, geom2 in self.pairs:
+            sgpd_result = GeoSeries(geom).intersects(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).intersects(
+                gpd.GeoSeries(geom2), align=True
+            )
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).intersects(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).intersects(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).intersects(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).intersects(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_intersection(self):
         geometries = [
@@ -782,180 +777,148 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
         assert sgpd_result.index.to_pandas().equals(gpd_result.index)
 
-        for g1 in geometries:
-            for g2 in geometries:
-                sgpd_result = GeoSeries(g1).intersection(GeoSeries(g2))
-                gpd_result = gpd.GeoSeries(g1).intersection(gpd.GeoSeries(g2))
-                self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
-
         # Ensure both align True and False work correctly
-        for _, g1 in self.geoms:
-            for _, g2 in self.geoms:
-                gpd_series1, gpd_series2 = gpd.GeoSeries(g1), gpd.GeoSeries(g2)
-                # The original geopandas intersection method fails on invalid geometries
-                if not gpd_series1.is_valid.all() or not gpd_series2.is_valid.all():
-                    continue
-                sgpd_result = GeoSeries(g1).intersection(GeoSeries(g2))
-                gpd_result = gpd_series1.intersection(gpd_series2)
-                self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+        for geom, geom2 in self.pairs:
+            gpd_series1, gpd_series2 = gpd.GeoSeries(geom), gpd.GeoSeries(geom2)
+            # The original geopandas intersection method fails on invalid geometries
+            if not gpd_series1.is_valid.all() or not gpd_series2.is_valid.all():
+                continue
+            sgpd_result = GeoSeries(geom).intersection(GeoSeries(geom2))
+            gpd_result = gpd_series1.intersection(gpd_series2)
+            self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
-                if len(g1) == len(g2):
-                    sgpd_result = GeoSeries(g1).intersection(GeoSeries(g2), align=False)
-                    gpd_result = gpd_series1.intersection(gpd_series2, align=False)
-                    self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).intersection(
+                    GeoSeries(geom2), align=False
+                )
+                gpd_result = gpd_series1.intersection(gpd_series2, align=False)
+                self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
 
     def test_intersection_all(self):
         pass
 
     def test_overlaps(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                # Sedona's results differ from geopandas for these cases
-                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
-                    continue
+        for geom, geom2 in self.pairs:
+            # Sedona's results differ from geopandas for these cases
+            if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                continue
 
-                sgpd_result = GeoSeries(geom).overlaps(GeoSeries(geom2, align=True))
+            sgpd_result = GeoSeries(geom).overlaps(GeoSeries(geom2, align=True))
+            gpd_result = gpd.GeoSeries(geom).overlaps(gpd.GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).overlaps(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).overlaps(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).overlaps(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).overlaps(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_touches(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if self.contains_any_geom_collection(geom, geom2):
-                    continue
-                sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=True)
+        for geom, geom2 in self.pairs:
+            if self.contains_any_geom_collection(geom, geom2):
+                continue
+            sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).touches(gpd.GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).touches(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=False)
-                    gpd_result = gpd.GeoSeries(geom).touches(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_within(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
-                    continue
+        for geom, geom2 in self.pairs:
+            if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                continue
 
-                sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=True)
+            sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).within(gpd.GeoSeries(geom2), align=True)
+
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).within(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
-
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=False)
-                    gpd_result = gpd.GeoSeries(geom).within(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_covers(self):
         if parse_version(gpd.__version__) < parse_version("0.8.0"):
             pytest.skip("geopandas < 0.8.0 does not support covered_by")
 
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
-                    continue
+        for geom, geom2 in self.pairs:
+            if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                continue
 
-                sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=True)
+            sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).covers(gpd.GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).covers(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=False)
-                    gpd_result = gpd.GeoSeries(geom).covers(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_covered_by(self):
         if parse_version(shapely.__version__) < parse_version("2.0.0"):
             pytest.skip("shapely < 2.0.0 does not support covered_by")
 
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
-                    continue
+        for geom, geom2 in self.pairs:
+            if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                continue
 
-                sgpd_result = GeoSeries(geom).covered_by(GeoSeries(geom2), align=True)
+            sgpd_result = GeoSeries(geom).covered_by(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).covered_by(
+                gpd.GeoSeries(geom2), align=True
+            )
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).covered_by(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).covered_by(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).covered_by(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).covered_by(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_distance(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                sgpd_result = GeoSeries(geom).distance(GeoSeries(geom2), align=True)
+        for geom, geom2 in self.pairs:
+            sgpd_result = GeoSeries(geom).distance(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).distance(gpd.GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).distance(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).distance(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).distance(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).distance(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_contains(self):
-        for _, geom in self.geoms:
-            for _, geom2 in self.geoms:
-                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
-                    continue
-                sgpd_result = GeoSeries(geom).contains(GeoSeries(geom2), align=True)
+        for geom, geom2 in self.pairs:
+            if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                continue
+            sgpd_result = GeoSeries(geom).contains(GeoSeries(geom2), align=True)
+            gpd_result = gpd.GeoSeries(geom).contains(gpd.GeoSeries(geom2), align=True)
+            self.check_pd_series_equal(sgpd_result, gpd_result)
+
+            if len(geom) == len(geom2):
+                sgpd_result = GeoSeries(geom).contains(GeoSeries(geom2), align=False)
                 gpd_result = gpd.GeoSeries(geom).contains(
-                    gpd.GeoSeries(geom2), align=True
+                    gpd.GeoSeries(geom2), align=False
                 )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
-
-                if len(geom) == len(geom2):
-                    sgpd_result = GeoSeries(geom).contains(
-                        GeoSeries(geom2), align=False
-                    )
-                    gpd_result = gpd.GeoSeries(geom).contains(
-                        gpd.GeoSeries(geom2), align=False
-                    )
-                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_contains_properly(self):
         pass
 
     def test_set_crs(self):
-        for _, geom in self.geoms:
+        for geom in self.geoms:
             sgpd_series = GeoSeries(geom)
             gpd_series = gpd.GeoSeries(geom)
             assert sgpd_series.crs == gpd_series.crs

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -207,13 +207,6 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         assert type(area) is ps.Series
         assert area.count() == 2
 
-    def test_buffer_then_geoparquet(self):
-        temp_file_path = os.path.join(
-            self.tempdir, next(tempfile._get_candidate_names()) + ".parquet"
-        )
-        self.g1.buffer(0.2).to_parquet(temp_file_path)
-        assert os.path.exists(temp_file_path)
-
     def test_simplify(self):
         for geom in self.geoms:
             if isinstance(geom[0], LinearRing):

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -657,11 +657,36 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         gpd_result = gpd.GeoSeries([]).union_all()
         self.check_geom_equals(sgpd_result, gpd_result)
 
+    def test_crosses(self):
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if self.contains_any_geom_collection(geom, geom2):
+                    continue
+
+                # We explicitly specify align=True to quite warnings in geopandas, despite it being the default
+                gpd_result = gpd.GeoSeries(geom).crosses(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=True)
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).crosses(GeoSeries(geom2), align=False)
+                    gpd_result = gpd.GeoSeries(geom).crosses(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_disjoint(self):
+        pass
+
     def test_intersects(self):
         for _, geom in self.geoms:
             for _, geom2 in self.geoms:
-                sgpd_result = GeoSeries(geom).intersects(GeoSeries(geom2))
-                gpd_result = gpd.GeoSeries(geom).intersects(gpd.GeoSeries(geom2))
+                sgpd_result = GeoSeries(geom).intersects(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).intersects(
+                    gpd.GeoSeries(geom2), align=True
+                )
                 self.check_pd_series_equal(sgpd_result, gpd_result)
 
                 if len(geom) == len(geom2):
@@ -721,8 +746,149 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
     def test_intersection_all(self):
         pass
 
+    def test_overlaps(self):
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                # Sedona's results differ from geopandas for these cases
+                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                    continue
+
+                sgpd_result = GeoSeries(geom).overlaps(GeoSeries(geom2, align=True))
+                gpd_result = gpd.GeoSeries(geom).overlaps(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).overlaps(
+                        GeoSeries(geom2), align=False
+                    )
+                    gpd_result = gpd.GeoSeries(geom).overlaps(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_touches(self):
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if self.contains_any_geom_collection(geom, geom2):
+                    continue
+                sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).touches(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).touches(GeoSeries(geom2), align=False)
+                    gpd_result = gpd.GeoSeries(geom).touches(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_within(self):
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                    continue
+
+                sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).within(
+                    gpd.GeoSeries(geom2), align=True
+                )
+
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).within(GeoSeries(geom2), align=False)
+                    gpd_result = gpd.GeoSeries(geom).within(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_covers(self):
+        if parse_version(gpd.__version__) < parse_version("0.8.0"):
+            pytest.skip("geopandas < 0.8.0 does not support covered_by")
+
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                    continue
+
+                sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).covers(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).covers(GeoSeries(geom2), align=False)
+                    gpd_result = gpd.GeoSeries(geom).covers(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_covered_by(self):
+        if parse_version(shapely.__version__) < parse_version("2.0.0"):
+            pytest.skip("shapely < 2.0.0 does not support covered_by")
+
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                    continue
+
+                sgpd_result = GeoSeries(geom).covered_by(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).covered_by(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).covered_by(
+                        GeoSeries(geom2), align=False
+                    )
+                    gpd_result = gpd.GeoSeries(geom).covered_by(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
+    def test_distance(self):
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                sgpd_result = GeoSeries(geom).distance(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).distance(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).distance(
+                        GeoSeries(geom2), align=False
+                    )
+                    gpd_result = gpd.GeoSeries(geom).distance(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
+
     def test_contains(self):
-        pass
+        for _, geom in self.geoms:
+            for _, geom2 in self.geoms:
+                if geom == geom2 or self.contains_any_geom_collection(geom, geom2):
+                    continue
+                sgpd_result = GeoSeries(geom).contains(GeoSeries(geom2), align=True)
+                gpd_result = gpd.GeoSeries(geom).contains(
+                    gpd.GeoSeries(geom2), align=True
+                )
+                self.check_pd_series_equal(sgpd_result, gpd_result)
+
+                if len(geom) == len(geom2):
+                    sgpd_result = GeoSeries(geom).contains(
+                        GeoSeries(geom2), align=False
+                    )
+                    gpd_result = gpd.GeoSeries(geom).contains(
+                        gpd.GeoSeries(geom2), align=False
+                    )
+                    self.check_pd_series_equal(sgpd_result, gpd_result)
 
     def test_contains_properly(self):
         pass

--- a/python/tests/geopandas/test_match_geopandas_series.py
+++ b/python/tests/geopandas/test_match_geopandas_series.py
@@ -140,7 +140,13 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         for _, geom in self.geoms:
             sgpd_result = GeoSeries(geom)
             gpd_result = gpd.GeoSeries(geom)
+            # The below method calls to_geopandas() on sgpd_result, so we don't do it here
             self.check_sgpd_equals_gpd(sgpd_result, gpd_result)
+
+        # Ensure we have the same result for empty GeoSeries
+        sgpd_series = GeoSeries([])
+        gpd_series = gpd.GeoSeries([])
+        self.check_sgpd_equals_gpd(sgpd_series, gpd_series)
 
     def test_psdf(self):
         # this is to make sure the spark session works with pandas on spark api
@@ -428,7 +434,8 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
     def test_is_valid_reason(self):
         # is_valid_reason was added in geopandas 1.0.0
         if parse_version(gpd.__version__) < parse_version("1.0.0"):
-            return
+            pytest.skip("geopandas is_valid_reason requires version 1.0.0 or higher")
+
         data = [
             Polygon([(0, 0), (1, 1), (0, 1)]),
             Polygon([(0, 0), (1, 1), (1, 0), (0, 1)]),  # bowtie geometry
@@ -499,7 +506,7 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
     def test_get_geometry(self):
         if parse_version(gpd.__version__) < parse_version("1.0.0"):
-            return
+            pytest.skip("geopandas get_geometry requires version 1.0.0 or higher")
 
         for _, geom in self.geoms:
             # test negative index, in-bounds index, and out of bounds index
@@ -591,7 +598,8 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
 
         # 'structure' method requires shapely >= 2.1.0
         if shapely.__version__ < "2.1.0":
-            return
+            pytest.skip("geopandas make_valid requires shapely >= 2.1.0")
+
         for _, geom in self.geoms:
             sgpd_result = GeoSeries(geom).make_valid(method="structure")
             gpd_result = gpd.GeoSeries(geom).make_valid(method="structure")
@@ -634,7 +642,20 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
         pass
 
     def test_union_all(self):
-        pass
+        if parse_version(gpd.__version__) < parse_version("1.1.0"):
+            pytest.skip("geopandas union_all requires version 1.1.0 or higher")
+
+        # Union all the valid geometries
+        # Neither our nor geopandas' implementation supports invalid geometries
+        lst = [g for _, geom in self.geoms for g in geom if g.is_valid]
+        sgpd_result = GeoSeries(lst).union_all()
+        gpd_result = gpd.GeoSeries(lst).union_all()
+        self.check_geom_equals(sgpd_result, gpd_result)
+
+        # Ensure we have the same result for empty GeoSeries
+        sgpd_result = GeoSeries([]).union_all()
+        gpd_result = gpd.GeoSeries([]).union_all()
+        self.check_geom_equals(sgpd_result, gpd_result)
 
     def test_intersects(self):
         for _, geom in self.geoms:
@@ -719,3 +740,8 @@ class TestMatchGeopandasSeries(TestGeopandasBase):
             sgpd_series = sgpd_series.set_crs(epsg=3857, allow_override=True)
             gpd_series = gpd_series.set_crs(epsg=3857, allow_override=True)
             assert sgpd_series.crs == gpd_series.crs
+
+        # Ensure we have the same result for empty GeoSeries
+        sgpd_series = GeoSeries([])
+        gpd_series = gpd.GeoSeries([])
+        assert sgpd_series.crs == gpd_series.crs

--- a/python/tests/geopandas/test_sindex.py
+++ b/python/tests/geopandas/test_sindex.py
@@ -15,15 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 import numpy as np
+import shapely
 from pyspark.sql.functions import expr
 from shapely.geometry import Point, Polygon, LineString
 
 from tests.test_base import TestBase
 from sedona.geopandas import GeoSeries
 from sedona.geopandas.sindex import SpatialIndex
+from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestSpatialIndex(TestBase):
     """Tests for the spatial index functionality in GeoSeries."""
 
@@ -56,11 +63,17 @@ class TestSpatialIndex(TestBase):
             ]
         )
 
-    def test_sindex_property_exists(self):
+    def test_geoseries_sindex_property_exists(self):
         """Test that the sindex property exists on GeoSeries."""
         assert hasattr(self.points, "sindex")
         assert hasattr(self.polygons, "sindex")
         assert hasattr(self.lines, "sindex")
+
+    def test_geodataframe_sindex_property_exists(self):
+        """Test that the sindex property exists on GeoDataFrame."""
+        assert hasattr(self.points.to_geoframe(), "sindex")
+        assert hasattr(self.polygons.to_geoframe(), "sindex")
+        assert hasattr(self.lines.to_geoframe(), "sindex")
 
     def test_query_with_point(self):
         """Test querying the spatial index with a point geometry."""

--- a/python/tests/geopandas/test_sjoin.py
+++ b/python/tests/geopandas/test_sjoin.py
@@ -17,12 +17,18 @@
 import shutil
 import tempfile
 import pytest
+import shapely
 
 from shapely.geometry import Polygon, Point, LineString
 from sedona.geopandas import GeoSeries, GeoDataFrame, sjoin
 from tests.test_base import TestBase
+from packaging.version import parse as parse_version
 
 
+@pytest.mark.skipif(
+    parse_version(shapely.__version__) < parse_version("2.0.0"),
+    reason=f"Tests require shapely>=2.0.0, but found v{shapely.__version__}",
+)
 class TestSpatialJoin(TestBase):
     def setup_method(self):
         self.tempdir = tempfile.mkdtemp()

--- a/python/tests/sql/test_dataframe_api.py
+++ b/python/tests/sql/test_dataframe_api.py
@@ -1758,11 +1758,8 @@ class TestDataFrameAPI(TestBase):
             future.result()
 
     @pytest.mark.skipif(
-        os.getenv("SPARK_REMOTE") is not None,
-        reason="Checkpoint dir is not available in Spark Connect",
-    )
-    @pytest.mark.skipif(
-        pyspark.__version__ >= "4", reason="DBSCAN is not supported yet on Spark 4"
+        os.getenv("SPARK_REMOTE") is not None and pyspark.__version__ < "4.0.0",
+        reason="DBSCAN requires checkpoint directory which is not available in Spark Connect mode before Spark 4.0.0",
     )
     def test_dbscan(self):
         df = self.spark.createDataFrame([{"id": 1, "x": 2, "y": 3}]).withColumn(
@@ -1772,8 +1769,8 @@ class TestDataFrameAPI(TestBase):
         df.withColumn("dbscan", ST_DBSCAN("geometry", 1.0, 2, False)).collect()
 
     @pytest.mark.skipif(
-        os.getenv("SPARK_REMOTE") is not None,
-        reason="Checkpoint dir is not available in Spark Connect",
+        os.getenv("SPARK_REMOTE") is not None and pyspark.__version__ < "4.0.0",
+        reason="LOF requires checkpoint directory which is not available in Spark Connect mode before Spark 4.0.0",
     )
     def test_lof(self):
         df = self.spark.createDataFrame([{"id": 1, "x": 2, "y": 3}]).withColumn(

--- a/python/tests/stac/test_client.py
+++ b/python/tests/stac/test_client.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections.abc
 from sedona.spark.stac.client import Client
 from pyspark.sql import DataFrame
 
@@ -36,7 +37,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) > 0
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_ids(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -46,7 +47,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 1
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_single_id(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -56,7 +57,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 1
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_bbox_and_datetime(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -67,7 +68,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) > 0
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_multiple_bboxes_and_intervals(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -82,7 +83,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) > 0
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_bbox_and_non_overlapping_intervals(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -96,7 +97,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 20
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_max_items(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -108,7 +109,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 5
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_single_datetime(self) -> None:
         from datetime import datetime
@@ -121,7 +122,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 0
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_YYYY(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -132,7 +133,7 @@ class TestStacClient(TestBase):
             return_dataframe=False,
         )
         assert items is not None
-        assert len(list(items)) == 20
+        assert isinstance(items, collections.abc.Iterator)
 
     def test_search_with_return_dataframe(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -142,7 +143,6 @@ class TestStacClient(TestBase):
             datetime=["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"],
         )
         assert df is not None
-        assert df.count() == 20
         assert isinstance(df, DataFrame)
 
     def test_search_with_catalog_url(self) -> None:

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -188,6 +188,131 @@ class TestStacReader(TestBase):
             df_loaded = collection.spark.read.format("geoparquet").load(output_path)
             assert df_loaded.count() == 20, "Loaded GeoParquet file is empty"
 
+    def test_get_items_with_wkt_geometry(self) -> None:
+        """Test that WKT geometry strings are properly handled for spatial filtering."""
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with WKT polygon geometry
+        wkt_polygon = "POLYGON((90 -73, 105 -73, 105 -69, 90 -69, 90 -73))"
+        items_with_wkt = list(collection.get_items(geometry=wkt_polygon))
+
+        # Both should return similar number of items (may not be exactly same due to geometry differences)
+        assert items_with_wkt is not None
+        assert len(items_with_wkt) > 0
+
+    def test_get_dataframe_with_shapely_geometry(self) -> None:
+        """Test that Shapely geometry objects are properly handled for spatial filtering."""
+        from shapely.geometry import Polygon
+
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with Shapely polygon geometry
+        shapely_polygon = Polygon(
+            [(90, -73), (105, -73), (105, -69), (90, -69), (90, -73)]
+        )
+        df_with_shapely = collection.get_dataframe(geometry=shapely_polygon)
+
+        # Both should return similar number of items
+        assert df_with_shapely is not None
+        assert df_with_shapely.count() > 0
+
+    def test_get_items_with_geometry_list(self) -> None:
+        """Test that lists of geometry objects are properly handled."""
+        from shapely.geometry import Polygon
+
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with list of geometries (both WKT and Shapely)
+        wkt_polygon = "POLYGON((90 -73, 105 -73, 105 -69, 90 -69, 90 -73))"
+        shapely_polygon = Polygon(
+            [(-100, -72), (-90, -72), (-90, -62), (-100, -62), (-100, -72)]
+        )
+        geometry_list = [wkt_polygon, shapely_polygon]
+
+        items_with_geom_list = list(collection.get_items(geometry=geometry_list))
+
+        # Should return items from both geometries
+        assert items_with_geom_list is not None
+        assert len(items_with_geom_list) > 0
+
+    def test_geometry_takes_precedence_over_bbox(self) -> None:
+        """Test that geometry parameter takes precedence over bbox when both are provided."""
+        from shapely.geometry import Polygon
+
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Define different spatial extents
+        bbox = [-180.0, -90.0, 180.0, 90.0]  # World bbox
+        small_polygon = Polygon(
+            [(90, -73), (105, -73), (105, -69), (90, -69), (90, -73)]
+        )  # Small area
+
+        # When both are provided, geometry should take precedence
+        items_with_both = list(collection.get_items(bbox=bbox, geometry=small_polygon))
+        items_with_geom_only = list(collection.get_items(geometry=small_polygon))
+
+        # Results should be identical since geometry takes precedence
+        assert items_with_both is not None
+        assert items_with_geom_only is not None
+        assert len(items_with_both) == len(items_with_geom_only)
+        assert len(items_with_both) > 0
+
+    def test_get_dataframe_with_geometry_and_datetime(self) -> None:
+        """Test that geometry and datetime filters work together."""
+        from shapely.geometry import Polygon
+
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Define spatial and temporal filters
+        polygon = Polygon([(90, -73), (105, -73), (105, -69), (90, -69), (90, -73)])
+        datetime_range = ["2006-12-01T00:00:00Z", "2006-12-27T03:00:00Z"]
+
+        df_with_both = collection.get_dataframe(
+            geometry=polygon, datetime=datetime_range
+        )
+        df_with_geom_only = collection.get_dataframe(geometry=polygon)
+
+        # Combined filter should return fewer or equal items than geometry-only filter
+        assert df_with_both is not None
+        assert df_with_geom_only is not None
+        assert df_with_both.count() <= df_with_geom_only.count()
+
+    def test_save_to_geoparquet_with_geometry(self) -> None:
+        """Test saving to GeoParquet with geometry parameter."""
+        from shapely.geometry import Polygon
+        import tempfile
+        import os
+
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Create a temporary directory for the output path and clean it up after the test
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            output_path = f"{tmpdirname}/test_geometry_geoparquet_output"
+
+            # Define spatial and temporal extents
+            polygon = Polygon(
+                [(-180, -90), (180, -90), (180, 90), (-180, 90), (-180, -90)]
+            )
+            datetime_range = [["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]]
+
+            # Call the method to save the DataFrame to GeoParquet
+            collection.save_to_geoparquet(
+                output_path=output_path, geometry=polygon, datetime=datetime_range
+            )
+
+            # Check if the file was created
+            assert os.path.exists(output_path), "GeoParquet file was not created"
+
+            # Optionally, you can load the file back and check its contents
+            df_loaded = collection.spark.read.format("geoparquet").load(output_path)
+            assert df_loaded.count() > 0, "Loaded GeoParquet file is empty"
+
     def test_get_items_with_tuple_datetime(self) -> None:
         """Test that tuples are properly handled as datetime input (same as lists)."""
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections.abc
+
+from pyspark.sql import DataFrame
 from sedona.spark.stac.client import Client
 from sedona.spark.stac.collection_client import CollectionClient
 
@@ -38,7 +41,7 @@ class TestStacReader(TestBase):
         collection = client.get_collection("aster-l1t")
         df = collection.get_dataframe()
         assert df is not None
-        assert df.count() == 20
+        assert isinstance(df, DataFrame)
 
     def test_get_dataframe_with_spatial_extent(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -46,7 +49,7 @@ class TestStacReader(TestBase):
         bbox = [[-180.0, -90.0, 180.0, 90.0]]
         df = collection.get_dataframe(bbox=bbox)
         assert df is not None
-        assert df.count() > 0
+        assert isinstance(df, DataFrame)
 
     def test_get_dataframe_with_temporal_extent(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -54,7 +57,7 @@ class TestStacReader(TestBase):
         datetime = [["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]]
         df = collection.get_dataframe(datetime=datetime)
         assert df is not None
-        assert df.count() > 0
+        assert isinstance(df, DataFrame)
 
     def test_get_dataframe_with_both_extents(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -63,7 +66,7 @@ class TestStacReader(TestBase):
         datetime = [["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]]
         df = collection.get_dataframe(bbox=bbox, datetime=datetime)
         assert df is not None
-        assert df.count() > 0
+        assert isinstance(df, DataFrame)
 
     def test_get_items_with_spatial_extent(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -71,7 +74,6 @@ class TestStacReader(TestBase):
         bbox = [[-100.0, -72.0, 105.0, -69.0]]
         items = list(collection.get_items(bbox=bbox))
         assert items is not None
-        assert len(items) > 0
 
     def test_get_items_with_temporal_extent(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -79,7 +81,6 @@ class TestStacReader(TestBase):
         datetime = [["2006-12-01T00:00:00Z", "2006-12-27T02:00:00Z"]]
         items = list(collection.get_items(datetime=datetime))
         assert items is not None
-        assert len(items) == 16
 
     def test_get_items_with_both_extents(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -88,7 +89,6 @@ class TestStacReader(TestBase):
         datetime = [["2006-12-01T00:00:00Z", "2006-12-27T03:00:00Z"]]
         items = list(collection.get_items(bbox=bbox, datetime=datetime))
         assert items is not None
-        assert len(items) > 0
 
     def test_get_items_with_multiple_bboxes_and_interval(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -111,7 +111,6 @@ class TestStacReader(TestBase):
         datetime = [["2006-12-01T00:00:00Z", "2006-12-27T03:00:00Z"]]
         items = list(collection.get_items(bbox=bbox, datetime=datetime))
         assert items is not None
-        assert len(items) > 0
 
     def test_get_items_with_ids(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -119,16 +118,12 @@ class TestStacReader(TestBase):
         ids = ["AST_L1T_00312272006020322_20150518201805", "item2", "item3"]
         items = list(collection.get_items(*ids))
         assert items is not None
-        assert len(items) == 1
-        for item in items:
-            assert item.id in ids
 
     def test_get_items_with_id(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
         collection = client.get_collection("aster-l1t")
         items = list(collection.get_items("AST_L1T_00312272006020322_20150518201805"))
         assert items is not None
-        assert len(items) == 1
 
     def test_get_items_with_bbox_and_non_overlapping_intervals(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -140,7 +135,6 @@ class TestStacReader(TestBase):
         ]
         items = list(collection.get_items(bbox=bbox, datetime=datetime))
         assert items is not None
-        assert len(items) == 20
 
     def test_get_items_with_bbox_and_interval(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -149,7 +143,6 @@ class TestStacReader(TestBase):
         interval = ["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]
         items = list(collection.get_items(bbox=bbox, datetime=interval))
         assert items is not None
-        assert len(items) > 0
 
     def test_get_dataframe_with_bbox_and_interval(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -158,7 +151,6 @@ class TestStacReader(TestBase):
         interval = ["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]
         df = collection.get_dataframe(bbox=bbox, datetime=interval)
         assert df is not None
-        assert df.count() > 0
 
     def test_save_to_geoparquet(self) -> None:
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -184,10 +176,6 @@ class TestStacReader(TestBase):
 
             assert os.path.exists(output_path), "GeoParquet file was not created"
 
-            # Optionally, you can load the file back and check its contents
-            df_loaded = collection.spark.read.format("geoparquet").load(output_path)
-            assert df_loaded.count() == 20, "Loaded GeoParquet file is empty"
-
     def test_get_items_with_wkt_geometry(self) -> None:
         """Test that WKT geometry strings are properly handled for spatial filtering."""
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -199,7 +187,6 @@ class TestStacReader(TestBase):
 
         # Both should return similar number of items (may not be exactly same due to geometry differences)
         assert items_with_wkt is not None
-        assert len(items_with_wkt) > 0
 
     def test_get_dataframe_with_shapely_geometry(self) -> None:
         """Test that Shapely geometry objects are properly handled for spatial filtering."""
@@ -216,7 +203,6 @@ class TestStacReader(TestBase):
 
         # Both should return similar number of items
         assert df_with_shapely is not None
-        assert df_with_shapely.count() > 0
 
     def test_get_items_with_geometry_list(self) -> None:
         """Test that lists of geometry objects are properly handled."""
@@ -236,7 +222,6 @@ class TestStacReader(TestBase):
 
         # Should return items from both geometries
         assert items_with_geom_list is not None
-        assert len(items_with_geom_list) > 0
 
     def test_geometry_takes_precedence_over_bbox(self) -> None:
         """Test that geometry parameter takes precedence over bbox when both are provided."""
@@ -258,8 +243,6 @@ class TestStacReader(TestBase):
         # Results should be identical since geometry takes precedence
         assert items_with_both is not None
         assert items_with_geom_only is not None
-        assert len(items_with_both) == len(items_with_geom_only)
-        assert len(items_with_both) > 0
 
     def test_get_dataframe_with_geometry_and_datetime(self) -> None:
         """Test that geometry and datetime filters work together."""
@@ -280,7 +263,6 @@ class TestStacReader(TestBase):
         # Combined filter should return fewer or equal items than geometry-only filter
         assert df_with_both is not None
         assert df_with_geom_only is not None
-        assert df_with_both.count() <= df_with_geom_only.count()
 
     def test_save_to_geoparquet_with_geometry(self) -> None:
         """Test saving to GeoParquet with geometry parameter."""
@@ -309,10 +291,6 @@ class TestStacReader(TestBase):
             # Check if the file was created
             assert os.path.exists(output_path), "GeoParquet file was not created"
 
-            # Optionally, you can load the file back and check its contents
-            df_loaded = collection.spark.read.format("geoparquet").load(output_path)
-            assert df_loaded.count() > 0, "Loaded GeoParquet file is empty"
-
     def test_get_items_with_tuple_datetime(self) -> None:
         """Test that tuples are properly handled as datetime input (same as lists)."""
         client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
@@ -329,8 +307,6 @@ class TestStacReader(TestBase):
         # Both should return the same number of items
         assert items_with_tuple is not None
         assert items_with_list is not None
-        assert len(items_with_tuple) == len(items_with_list)
-        assert len(items_with_tuple) == 16
 
     def test_get_dataframe_with_tuple_datetime(self) -> None:
         """Test that tuples are properly handled as datetime input for dataframes."""
@@ -348,5 +324,3 @@ class TestStacReader(TestBase):
         # Both should return the same count
         assert df_with_tuple is not None
         assert df_with_list is not None
-        assert df_with_tuple.count() == df_with_list.count()
-        assert df_with_tuple.count() > 0

--- a/python/tests/stac/test_collection_client.py
+++ b/python/tests/stac/test_collection_client.py
@@ -187,3 +187,41 @@ class TestStacReader(TestBase):
             # Optionally, you can load the file back and check its contents
             df_loaded = collection.spark.read.format("geoparquet").load(output_path)
             assert df_loaded.count() == 20, "Loaded GeoParquet file is empty"
+
+    def test_get_items_with_tuple_datetime(self) -> None:
+        """Test that tuples are properly handled as datetime input (same as lists)."""
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with tuple instead of list
+        datetime_tuple = ("2006-12-01T00:00:00Z", "2006-12-27T02:00:00Z")
+        items_with_tuple = list(collection.get_items(datetime=datetime_tuple))
+
+        # Test with list for comparison
+        datetime_list = ["2006-12-01T00:00:00Z", "2006-12-27T02:00:00Z"]
+        items_with_list = list(collection.get_items(datetime=datetime_list))
+
+        # Both should return the same number of items
+        assert items_with_tuple is not None
+        assert items_with_list is not None
+        assert len(items_with_tuple) == len(items_with_list)
+        assert len(items_with_tuple) == 16
+
+    def test_get_dataframe_with_tuple_datetime(self) -> None:
+        """Test that tuples are properly handled as datetime input for dataframes."""
+        client = Client.open(STAC_URLS["PLANETARY-COMPUTER"])
+        collection = client.get_collection("aster-l1t")
+
+        # Test with tuple instead of list
+        datetime_tuple = ("2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z")
+        df_with_tuple = collection.get_dataframe(datetime=datetime_tuple)
+
+        # Test with list for comparison
+        datetime_list = ["2006-01-01T00:00:00Z", "2007-01-01T00:00:00Z"]
+        df_with_list = collection.get_dataframe(datetime=datetime_list)
+
+        # Both should return the same count
+        assert df_with_tuple is not None
+        assert df_with_list is not None
+        assert df_with_tuple.count() == df_with_list.count()
+        assert df_with_tuple.count() > 0

--- a/python/tests/stats/test_dbscan.py
+++ b/python/tests/stats/test_dbscan.py
@@ -25,9 +25,12 @@ from sedona.spark.sql.st_constructors import ST_MakePoint
 from sedona.spark.sql.st_functions import ST_Buffer
 from sedona.spark.stats import dbscan
 
+import os
+
 
 @pytest.mark.skipif(
-    pyspark.__version__ >= "4", reason="DBSCAN is not supported yet on Spark 4"
+    os.getenv("SPARK_REMOTE") is not None and pyspark.__version__ < "4.0.0",
+    reason="DBSCAN requires checkpoint directory which is not available in Spark Connect mode before Spark 4.0.0",
 )
 class TestDBScan(TestBase):
 

--- a/python/tests/stats/test_local_outlier_factor.py
+++ b/python/tests/stats/test_local_outlier_factor.py
@@ -26,8 +26,14 @@ from tests.test_base import TestBase
 from sedona.spark.sql.st_constructors import ST_MakePoint
 from sedona.spark.sql.st_functions import ST_X, ST_Y
 from sedona.spark.stats import local_outlier_factor
+import os
+import pyspark
 
 
+@pytest.mark.skipif(
+    os.getenv("SPARK_REMOTE") is not None and pyspark.__version__ < "4.0.0",
+    reason="DBSCAN requires checkpoint directory which is not available in Spark Connect mode before Spark 4.0.0",
+)
 class TestLOF(TestBase):
     def get_small_data(self) -> DataFrame:
         schema = StructType(

--- a/python/tests/test_base.py
+++ b/python/tests/test_base.py
@@ -131,9 +131,12 @@ class TestBase:
 
         if not actual_geom.equals_exact(expected_geom, tolerance=tolerance):
             # If the exact equals check fails, perform a buffer check with tolerance
-            if actual_geom.buffer(tolerance).contains(
-                expected_geom
-            ) and expected_geom.buffer(tolerance).contains(actual_geom):
+            if (
+                actual_geom.is_valid
+                and actual_geom.buffer(tolerance).contains(expected_geom)
+                and expected_geom.is_valid
+                and expected_geom.buffer(tolerance).contains(actual_geom)
+            ):
                 return
             else:
                 # fail the test with error message

--- a/python/tests/test_base.py
+++ b/python/tests/test_base.py
@@ -44,9 +44,13 @@ class TestBase:
 
             builder = SedonaContext.builder().appName("SedonaSparkTest")
             if SPARK_REMOTE:
-                builder = builder.remote(SPARK_REMOTE).config(
-                    "spark.sql.extensions",
-                    "org.apache.sedona.sql.SedonaSqlExtensions",
+                builder = (
+                    builder.remote(SPARK_REMOTE)
+                    .config(
+                        "spark.sql.extensions",
+                        "org.apache.sedona.sql.SedonaSqlExtensions",
+                    )
+                    .config("spark.checkpoint.dir", mkdtemp())
                 )
 
                 # Connect is packaged with Spark 4+

--- a/python/tests/test_path_compatibility.py
+++ b/python/tests/test_path_compatibility.py
@@ -35,7 +35,7 @@ from sedona.sql.st_aggregates import ST_Union_Aggr
 from sedona.sql.st_constructors import ST_MakePoint
 from sedona.sql.st_functions import ST_X
 from sedona.sql.st_predicates import ST_Intersects
-from sedona.sql.types import GeographyType, GeometryType
+from sedona.sql.types import GeographyType, GeometryType, RasterType
 from sedona.stac.client import Client
 from sedona.stac.collection_client import CollectionClient
 from sedona.stats.clustering import dbscan
@@ -74,6 +74,7 @@ class TestPathCompatibility(TestBase):
         # Test GeographyType and GeometryType imports
         assert GeographyType is not None
         assert GeometryType is not None
+        assert RasterType is not None
 
     def test_spatial_operators_imports(self):
         # Test JoinQuery, KNNQuery, RangeQuery imports

--- a/python/tests/test_path_compatibility.py
+++ b/python/tests/test_path_compatibility.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# The test file is to ensure compatibility with the path structure and imports with Apache Sedona < 1.8.0
+# We will drop this test file in the future when we remove path compatibility for Apache Sedona < 1.8.0
+
+from sedona.core.SpatialRDD import CircleRDD, PolygonRDD, PointRDD
+from sedona.core.enums import FileDataSplitter, GridType, IndexType
+from sedona.core.formatMapper.geo_json_reader import GeoJsonReader
+from sedona.core.formatMapper.shapefileParser.shape_file_reader import ShapefileReader
+from sedona.core.geom.circle import Circle
+from sedona.core.geom.envelope import Envelope
+from sedona.core.geom.geography import Geography
+from sedona.core.spatialOperator import JoinQuery
+from sedona.core.spatialOperator import JoinQueryRaw, KNNQuery, RangeQuery
+from sedona.sql import st_aggregates as sta
+from sedona.sql import st_constructors as stc
+from sedona.sql import st_functions as stf
+from sedona.sql import st_predicates as stp
+from sedona.sql.st_aggregates import ST_Union_Aggr
+from sedona.sql.st_constructors import ST_MakePoint
+from sedona.sql.st_functions import ST_X
+from sedona.sql.st_predicates import ST_Intersects
+from sedona.sql.types import GeographyType, GeometryType
+from sedona.stac.client import Client
+from sedona.stac.collection_client import CollectionClient
+from sedona.stats.clustering import dbscan
+from sedona.stats.hotspot_detection.getis_ord import g_local
+from sedona.stats.weighting import (
+    add_distance_band_column,
+    add_binary_distance_band_column,
+)
+from sedona.utils.adapter import Adapter
+from sedona.utils.geoarrow import create_spatial_dataframe
+from sedona.utils.spatial_rdd_parser import GeoData
+from tests.test_base import TestBase
+
+
+class TestPathCompatibility(TestBase):
+
+    def test_spatial_rdd_imports(self):
+        # Test CircleRDD, PolygonRDD and PointRDD imports
+        assert PointRDD is not None
+        assert CircleRDD is not None
+        assert PolygonRDD is not None
+
+    def test_enums_imports(self):
+        # Test FileDataSplitter, GridType, IndexType imports
+        assert FileDataSplitter is not None
+        assert GridType is not None
+        assert IndexType is not None
+
+    def test_geometry_imports(self):
+        # Test Envelope, Geography, Circle imports
+        assert Envelope is not None
+        assert Geography is not None
+        assert Circle is not None
+
+    def test_sql_type_imports(self):
+        # Test GeographyType and GeometryType imports
+        assert GeographyType is not None
+        assert GeometryType is not None
+
+    def test_spatial_operators_imports(self):
+        # Test JoinQuery, KNNQuery, RangeQuery imports
+        assert JoinQuery is not None
+        assert JoinQueryRaw is not None
+        assert KNNQuery is not None
+        assert RangeQuery is not None
+
+    def test_stac_imports(self):
+        # Test STAC related imports
+        assert Client is not None
+        assert CollectionClient is not None
+
+    def test_stats_imports(self):
+        # Test statistics related imports
+        assert dbscan is not None
+        assert g_local is not None
+        assert add_distance_band_column is not None
+        assert add_binary_distance_band_column is not None
+
+    def test_util_imports(self):
+        # Test utility imports
+        assert Adapter is not None
+        assert GeoData is not None
+
+    def test_format_mapper_imports(self):
+        # Test GeoJsonReader and ShapefileReader imports
+        assert GeoJsonReader is not None
+        assert ShapefileReader is not None
+
+    def test_sql_module_imports(self):
+        # Test SQL module imports
+        assert sta is not None
+        assert stc is not None
+        assert stf is not None
+        assert stp is not None
+        assert ST_MakePoint is not None
+        assert ST_X is not None
+        assert ST_Union_Aggr is not None
+        assert ST_Intersects is not None
+
+    def test_geoarrow_import(self):
+        # Test create_spatial_dataframe import
+        assert create_spatial_dataframe is not None

--- a/python/tests/test_path_compatibility_all.py
+++ b/python/tests/test_path_compatibility_all.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# The test file is to ensure compatibility with the path structure and imports with Apache Sedona < 1.8.0
+# We will drop this test file in the future when we remove path compatibility for Apache Sedona < 1.8.0
+
+from sedona.spark import *
+from tests.test_base import TestBase
+
+
+class TestPathCompatibilityAll(TestBase):
+
+    def test_spatial_rdd_imports(self):
+        # Test CircleRDD, PolygonRDD and PointRDD imports
+        assert PointRDD is not None
+        assert CircleRDD is not None
+        assert PolygonRDD is not None
+
+    def test_enums_imports(self):
+        # Test FileDataSplitter, GridType, IndexType imports
+        assert FileDataSplitter is not None
+        assert GridType is not None
+        assert IndexType is not None
+
+    def test_geometry_imports(self):
+        # Test Envelope, Geography, Circle imports
+        assert Envelope is not None
+        assert Geography is not None
+        assert Circle is not None
+
+    def test_sql_type_imports(self):
+        # Test GeographyType and GeometryType imports
+        assert GeographyType is not None
+        assert GeometryType is not None
+
+    def test_spatial_operators_imports(self):
+        # Test JoinQuery, KNNQuery, RangeQuery imports
+        assert JoinQuery is not None
+        assert JoinQueryRaw is not None
+        assert KNNQuery is not None
+        assert RangeQuery is not None
+
+    def test_stac_imports(self):
+        # Test STAC related imports
+        assert Client is not None
+        assert CollectionClient is not None
+
+    def test_stats_imports(self):
+        # Test statistics related imports
+        assert dbscan is not None
+        assert g_local is not None
+        assert add_distance_band_column is not None
+        assert add_binary_distance_band_column is not None
+
+    def test_util_imports(self):
+        # Test utility imports
+        assert Adapter is not None
+        assert GeoData is not None
+
+    def test_format_mapper_imports(self):
+        # Test GeoJsonReader and ShapefileReader imports
+        assert GeoJsonReader is not None
+        assert ShapefileReader is not None
+
+    def test_sql_module_imports(self):
+        # Test SQL module imports
+        assert ST_MakePoint is not None
+        assert ST_X is not None
+        assert ST_Union_Aggr is not None
+        assert ST_Intersects is not None
+
+    def test_geoarrow_import(self):
+        # Test create_spatial_dataframe import
+        assert create_spatial_dataframe is not None

--- a/python/tests/test_path_compatibility_all.py
+++ b/python/tests/test_path_compatibility_all.py
@@ -46,6 +46,7 @@ class TestPathCompatibilityAll(TestBase):
         # Test GeographyType and GeometryType imports
         assert GeographyType is not None
         assert GeometryType is not None
+        assert RasterType is not None
 
     def test_spatial_operators_imports(self):
         # Test JoinQuery, KNNQuery, RangeQuery imports

--- a/python/tests/utils/test_geometry_serde.py
+++ b/python/tests/utils/test_geometry_serde.py
@@ -25,6 +25,7 @@ from shapely.geometry import (
     MultiPolygon,
     Point,
     Polygon,
+    LinearRing,
 )
 from shapely.wkt import loads as wkt_loads
 from tests.test_base import TestBase
@@ -103,6 +104,22 @@ class TestGeometrySerde(TestBase):
         assert geom.equals_exact(returned_geom, 1e-6)
 
     @pytest.mark.parametrize(
+        "geom",
+        [
+            LinearRing(),
+            LinearRing([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]),
+        ],
+    )
+    def test_linearring_spark_serde(self, geom):
+        returned_geom = TestGeometrySerde.spark.createDataFrame(
+            [(geom,)], StructType().add("geom", GeometryType())
+        ).take(1)[0][0]
+        # Shapely < 2.0.0 returns an empty GeometryCollection instead
+        if not geom.is_empty:
+            assert isinstance(returned_geom, LineString)
+        assert geom.equals(returned_geom)
+
+    @pytest.mark.parametrize(
         "wkt",
         [
             # empty geometries
@@ -143,6 +160,8 @@ class TestGeometrySerde(TestBase):
             "MULTIPOLYGON (EMPTY, EMPTY)",
             "GEOMETRYCOLLECTION (POINT (10 20), POINT EMPTY, LINESTRING (10 20, 30 40))",
             "GEOMETRYCOLLECTION (MULTIPOINT EMPTY, MULTILINESTRING EMPTY, MULTIPOLYGON EMPTY, GEOMETRYCOLLECTION EMPTY)",
+            "LINEARRING EMPTY",
+            "LINEARRING (-1 -1, -1 1, 1 1, 1 -1, -1 -1)",
         ],
     )
     def test_spark_serde_compatibility_with_scala(self, wkt):
@@ -181,6 +200,7 @@ class TestGeometrySerde(TestBase):
             "MULTIPOLYGON ZM (((10 10 10 1, 20 20 10 1, 20 10 10 1, 10 10 10 1)), "
             + "((0 0 0 1, 0 10 0 1, 10 10 0 1, 10 0 0 1, 0 0 0 1), (1 1 0 1, 1 2 0 1, 2 2 0 1, 2 1 0 1, 1 1 0 1)))",
             "GEOMETRYCOLLECTION (POINT ZM (10 20 30 1), LINESTRING ZM (10 20 30 1, 40 50 60 1))",
+            "LINEARRING ZM (0 0 0 1, 0 0 1 0, 0 1 0 0, 1 0 0 0, 0 0 0 1)",
         ],
     )
     def test_spark_serde_on_4d_geoms(self, wkt):
@@ -205,6 +225,7 @@ class TestGeometrySerde(TestBase):
             "MULTIPOLYGON M (((10 10 10, 20 20 10, 20 10 10, 10 10 10)), "
             + "((0 0 0, 0 10 0, 10 10 0, 10 0 0, 0 0 0), (1 1 0, 1 2 0, 2 2 0, 2 1 0, 1 1 0)))",
             "GEOMETRYCOLLECTION (POINT M (10 20 30), LINESTRING M (10 20 30, 40 50 60))",
+            "LINEARRING M (0 0 0, 1 0 0, 0 1 0, 0 0 1, 0 0 0)",
         ],
     )
     def test_spark_serde_on_xym_geoms(self, wkt):

--- a/python/tests/utils/test_geomserde_speedup.py
+++ b/python/tests/utils/test_geomserde_speedup.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
+import shapely
 from shapely.geometry import (
     GeometryCollection,
     LineString,
@@ -134,6 +136,15 @@ class TestGeomSerdeSpeedup:
             ),
         ]
         self._test_serde_roundtrip(geometry_collections)
+
+    @pytest.mark.skipif(
+        shapely.__version__ < "2", reason="SRID functions require Shapely >= 2.0"
+    )
+    def test_srid_roundtrip(self):
+        point = wkt_loads("POINT (1 2)")
+        point = shapely.set_srid(point, 1000)
+        point2 = TestGeomSerdeSpeedup.serde_roundtrip(point)
+        assert shapely.get_srid(point2) == 1000
 
     @staticmethod
     def _test_serde_roundtrip(geoms):

--- a/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
+++ b/snowflake/src/main/java/org/apache/sedona/snowflake/snowsql/UDFs.java
@@ -31,7 +31,6 @@ import org.apache.sedona.snowflake.snowsql.annotations.UDFAnnotations;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKBWriter;
 import org.xml.sax.SAXException;
 
 /**
@@ -1229,34 +1228,22 @@ public class UDFs {
 
   @UDFAnnotations.ParamMeta(argNames = {"geom", "zValue"})
   public static byte[] ST_Force3D(byte[] geom, double zValue) {
-    WKBWriter writer = new WKBWriter(3);
-    return GeometrySerde.serialize(
-        Functions.force3D(
-            GeometrySerde.deserialize(writer.write(GeometrySerde.deserialize(geom))), zValue));
+    return GeometrySerde.serialize(Functions.force3D(GeometrySerde.deserialize(geom), zValue));
   }
 
   @UDFAnnotations.ParamMeta(argNames = {"geom"})
   public static byte[] ST_Force3D(byte[] geom) {
-    WKBWriter writer = new WKBWriter(3);
-    return GeometrySerde.serialize(
-        Functions.force3D(
-            GeometrySerde.deserialize(writer.write(GeometrySerde.deserialize(geom)))));
+    return GeometrySerde.serialize(Functions.force3D(GeometrySerde.deserialize(geom)));
   }
 
   @UDFAnnotations.ParamMeta(argNames = {"geom", "zValue"})
   public static byte[] ST_Force3DZ(byte[] geom, double zValue) {
-    WKBWriter writer = new WKBWriter(3);
-    return GeometrySerde.serialize(
-        Functions.force3D(
-            GeometrySerde.deserialize(writer.write(GeometrySerde.deserialize(geom))), zValue));
+    return GeometrySerde.serialize(Functions.force3D(GeometrySerde.deserialize(geom), zValue));
   }
 
   @UDFAnnotations.ParamMeta(argNames = {"geom"})
   public static byte[] ST_Force3DZ(byte[] geom) {
-    WKBWriter writer = new WKBWriter(3);
-    return GeometrySerde.serialize(
-        Functions.force3D(
-            GeometrySerde.deserialize(writer.write(GeometrySerde.deserialize(geom)))));
+    return GeometrySerde.serialize(Functions.force3D(GeometrySerde.deserialize(geom)));
   }
 
   @UDFAnnotations.ParamMeta(argNames = {"geom"})

--- a/spark/common/pom.xml
+++ b/spark/common/pom.xml
@@ -185,9 +185,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>graphframes</groupId>
-            <artifactId>graphframes</artifactId>
-            <version>${graphframe.version}-s_${scala.compat.version}</version>
+            <groupId>io.graphframes</groupId>
+            <artifactId>graphframes-spark${spark.major.version}_${scala.compat.version}</artifactId>
+            <version>${graphframes.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -549,7 +549,7 @@ public class SpatialRDD<T extends Geometry> implements Serializable {
             new FlatMapFunction<Iterator<T>, String>() {
               @Override
               public Iterator<String> call(Iterator<T> iterator) throws Exception {
-                WKBWriter writer = new WKBWriter(3, true);
+                WKBWriter writer = GeomUtils.createWKBWriter(3, true);
                 ArrayList<String> wkbs = new ArrayList<>();
 
                 while (iterator.hasNext()) {

--- a/spark/common/src/main/scala-spark-3/org/apache/spark/sql/sedona_sql/DataFrameShims.scala
+++ b/spark/common/src/main/scala-spark-3/org/apache/spark/sql/sedona_sql/DataFrameShims.scala
@@ -18,24 +18,23 @@
  */
 package org.apache.spark.sql.sedona_sql
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
-import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.execution.aggregate.ScalaUDAF
-import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.expressions.UserDefinedAggregateFunction
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
-object DataFrameShims {
+import scala.reflect.ClassTag
 
-  private[sedona_sql] def wrapExpression[E <: Expression: ClassTag](args: Any*): Column = {
+private[sql] object DataFrameShims {
+
+  def wrapExpression[E <: Expression: ClassTag](args: Any*): Column = {
     wrapVarArgExpression[E](args)
   }
 
-  private[sedona_sql] def wrapVarArgExpression[E <: Expression: ClassTag](arg: Seq[Any]): Column = {
+  def wrapVarArgExpression[E <: Expression: ClassTag](arg: Seq[Any]): Column = {
     val runtimeClass = implicitly[ClassTag[E]].runtimeClass
     val exprArgs = arg.map(_ match {
       case c: Column => c.expr
@@ -49,7 +48,7 @@ object DataFrameShims {
     Column(expressionInstance)
   }
 
-  private[sedona_sql] def wrapAggregator[A <: UserDefinedAggregateFunction: ClassTag](arg: Any*): Column = {
+  def wrapAggregator[A <: UserDefinedAggregateFunction: ClassTag](arg: Any*): Column = {
     val runtimeClass = implicitly[ClassTag[A]].runtimeClass
     val exprArgs = arg.map(_ match {
       case c: Column => c.expr
@@ -65,7 +64,7 @@ object DataFrameShims {
     Column(scalaAggregator)
   }
 
-  private[sedona_sql] def createDataFrame(
+  def createDataFrame(
       sparkSession: SparkSession,
       rdd: RDD[InternalRow],
       schema: StructType): DataFrame = {

--- a/spark/common/src/main/scala/org/apache/sedona/python/wrapper/translation/CircleSerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/python/wrapper/translation/CircleSerializer.scala
@@ -19,14 +19,14 @@
 package org.apache.sedona.python.wrapper.translation
 
 import org.apache.sedona.common.geometryObjects.Circle
+import org.apache.sedona.common.utils.GeomUtils
 import org.apache.sedona.python.wrapper.utils.implicits.{DoubleImplicit, GeometryEnhancer, IntImplicit}
-import org.locationtech.jts.io.WKBWriter
 
 case class CircleSerializer(geometry: Circle) {
   private val isCircle = Array(1.toByte)
 
   def serialize: Array[Byte] = {
-    val wkbWriter = new WKBWriter(2, 2)
+    val wkbWriter = GeomUtils.createWKBWriter(2)
     val serializedGeom = wkbWriter.write(geometry.getCenterGeometry)
     val userDataBinary = geometry.userDataToUtf8ByteArray
     val userDataLengthArray = userDataBinary.length.toByteArray()

--- a/spark/common/src/main/scala/org/apache/sedona/python/wrapper/translation/GeometrySerializer.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/python/wrapper/translation/GeometrySerializer.scala
@@ -18,16 +18,16 @@
  */
 package org.apache.sedona.python.wrapper.translation
 
+import org.apache.sedona.common.utils.GeomUtils
 import org.apache.sedona.python.wrapper.utils.implicits.{GeometryEnhancer, IntImplicit}
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.io.WKBWriter
 
 case class GeometrySerializer(geometry: Geometry) {
 
   private val notCircle = Array(0.toByte)
 
   def serialize: Array[Byte] = {
-    val wkbWriter = new WKBWriter(2, 2)
+    val wkbWriter = GeomUtils.createWKBWriter(2)
     val serializedGeom = wkbWriter.write(geometry)
     val userDataBinary = geometry.userDataToUtf8ByteArray
     val userDataLengthArray = userDataBinary.length.toByteArray()

--- a/spark/common/src/main/scala/org/apache/sedona/stats/clustering/DBSCAN.scala
+++ b/spark/common/src/main/scala/org/apache/sedona/stats/clustering/DBSCAN.scala
@@ -109,7 +109,9 @@ object DBSCAN {
       .join(corePointsDF.alias("right"), col("left.dst") === col(s"right.id"))
       .select(col("left.src"), col(s"right.id").alias("dst"))
 
-    val connectedComponentsDF = GraphFrame(corePointsDF, coreEdgesDf).connectedComponents.run
+    val connectedComponentsDF = GraphFrame(corePointsDF, coreEdgesDf).connectedComponents
+      .setUseLabelsAsComponents(false)
+      .run
 
     val borderComponentsDF = borderPointsDF
       .select(struct("*").alias("leftContent"), explode(col("neighbors")).alias("neighbor"))

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/AggregateFunctions.scala
@@ -54,7 +54,7 @@ trait TraitSTAggregateExec {
   def finish(out: Geometry): Geometry = out
 }
 
-class ST_Union_Aggr(bufferSize: Int = 1000)
+private[apache] class ST_Union_Aggr(bufferSize: Int = 1000)
     extends Aggregator[Geometry, ListBuffer[Geometry], Geometry] {
 
   val serde = ExpressionEncoder[Geometry]()
@@ -98,7 +98,7 @@ class ST_Union_Aggr(bufferSize: Int = 1000)
 /**
  * Return the envelope boundary of the entire column
  */
-class ST_Envelope_Aggr
+private[apache] class ST_Envelope_Aggr
     extends Aggregator[Geometry, Geometry, Geometry]
     with TraitSTAggregateExec {
 
@@ -176,7 +176,7 @@ class ST_Envelope_Aggr
 /**
  * Return the polygon intersection of all Polygon in the given column
  */
-class ST_Intersection_Aggr
+private[apache] class ST_Intersection_Aggr
     extends Aggregator[Geometry, Geometry, Geometry]
     with TraitSTAggregateExec {
   def reduce(buffer: Geometry, input: Geometry): Geometry = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Constructors.scala
@@ -38,7 +38,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *   This function takes 2 parameters. The first parameter is the input geometry string, the
  *   second parameter is the delimiter. String format should be similar to CSV/TSV
  */
-case class ST_PointFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -51,7 +51,7 @@ case class ST_PointFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_PolygonFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_PolygonFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.polygonFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -64,7 +64,7 @@ case class ST_PolygonFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.lineFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -77,7 +77,7 @@ case class ST_LineFromText(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineStringFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineStringFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.lineStringFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -90,7 +90,7 @@ case class ST_LineStringFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -104,7 +104,7 @@ case class ST_GeomFromWKT(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geogFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -119,7 +119,7 @@ case class ST_GeogFromWKT(inputExpressions: Seq[Expression])
  *   This function takes a geometry string. The string format must be OGC Extended Well-Known text
  *   (EWKT) representation.
  */
-case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromEWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -133,7 +133,7 @@ case class ST_GeomFromEWKT(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeometryFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -147,7 +147,7 @@ case class ST_GeometryFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_GeomFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -162,7 +162,7 @@ case class ST_GeomFromText(inputExpressions: Seq[Expression])
  *   This function takes 1 parameter which is the utf-8 encoded geometry wkb string or the binary
  *   wkb array.
  */
-case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -202,7 +202,7 @@ case class ST_GeomFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -242,7 +242,7 @@ case class ST_GeomFromEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LineFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -299,7 +299,7 @@ case class ST_LineFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -356,7 +356,7 @@ case class ST_LinestringFromWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_PointFromWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromWKB(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with ImplicitCastInputTypes
@@ -420,7 +420,7 @@ case class ST_PointFromWKB(inputExpressions: Seq[Expression])
  *   This function takes 1 parameter which is the geometry string. The string format must be
  *   GeoJson.
  */
-case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with CodegenFallback
@@ -464,7 +464,7 @@ case class ST_GeomFromGeoJSON(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 2 parameter which are point x, y.
  */
-case class ST_Point(inputExpressions: Seq[Expression])
+private[apache] case class ST_Point(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.point _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -478,7 +478,7 @@ case class ST_Point(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 4 parameter which are point x, y, z and srid (default 0).
  */
-case class ST_PointZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointZ(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointZ _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -492,7 +492,7 @@ case class ST_PointZ(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes 4 parameter which are point x, y, m and srid (default 0).
  */
-case class ST_PointM(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -500,7 +500,7 @@ case class ST_PointM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_PointZM(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointZM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.pointZM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -508,7 +508,7 @@ case class ST_PointZM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePointM(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePointM(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.makePointM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -516,7 +516,7 @@ case class ST_MakePointM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(nullTolerantInferrableFunction4(Constructors.makePoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -529,7 +529,7 @@ case class ST_MakePoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction5(Constructors.makeEnvelope),
       inferrableFunction4(Constructors.makeEnvelope)) {
@@ -544,7 +544,7 @@ case class ST_MakeEnvelope(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.polygonFromEnvelope _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -552,7 +552,7 @@ case class ST_PolygonFromEnvelope(inputExpressions: Seq[Expression])
   }
 }
 
-trait UserDataGenerator {
+private[apache] trait UserDataGenerator {
   def generateUserData(
       minInputLength: Integer,
       inputExpressions: Seq[Expression],
@@ -568,28 +568,28 @@ trait UserDataGenerator {
   }
 }
 
-case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Constructors.geomFromGeoHash)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_PointFromGeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointFromGeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Constructors.pointFromGeoHash)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeomFromGML(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromGML(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromGML _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeomFromKML(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomFromKML(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomFromKML _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -602,7 +602,7 @@ case class ST_GeomFromKML(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_MPolyFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MPolyFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mPolyFromText _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
@@ -615,7 +615,7 @@ case class ST_MPolyFromText(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry string and a srid. The string format must be WKT.
  */
-case class ST_MLineFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MLineFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mLineFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -623,7 +623,7 @@ case class ST_MLineFromText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MPointFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_MPointFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.mPointFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -631,7 +631,7 @@ case class ST_MPointFromText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeomCollFromText(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeomCollFromText(inputExpressions: Seq[Expression])
     extends InferredExpression(Constructors.geomCollFromText _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Functions.scala
@@ -40,7 +40,7 @@ import org.apache.spark.util.Utils
 import com.mapzen.jpostal.{AddressExpander, AddressParser}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 
-case class ST_LabelPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LabelPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(Functions.labelPoint),
       inferrableFunction2(Functions.labelPoint),
@@ -57,7 +57,7 @@ case class ST_LabelPoint(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes two geometries and calculates the distance between two objects.
  */
-case class ST_Distance(inputExpressions: Seq[Expression])
+private[apache] case class ST_Distance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.distance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -65,7 +65,7 @@ case class ST_Distance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_YMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_YMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.yMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -73,7 +73,7 @@ case class ST_YMax(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_YMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_YMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.yMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -87,7 +87,7 @@ case class ST_YMin(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry and returns the maximum of all Z-coordinate values.
  */
-case class ST_ZMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_ZMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -101,7 +101,7 @@ case class ST_ZMax(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   This function takes a geometry and returns the minimum of all Z-coordinate values.
  */
-case class ST_ZMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_ZMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -109,7 +109,7 @@ case class ST_ZMin(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_3DDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_3DDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.distance3d _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -122,7 +122,7 @@ case class ST_3DDistance(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_ConcaveHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_ConcaveHull(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.concaveHull _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -135,7 +135,7 @@ case class ST_ConcaveHull(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_ConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_ConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.convexHull _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -143,7 +143,7 @@ case class ST_ConvexHull(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.crossesDateLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -156,7 +156,7 @@ case class ST_CrossesDateLine(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_NPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_NPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nPoints _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -169,7 +169,7 @@ case class ST_NPoints(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_NDims(inputExpressions: Seq[Expression])
+private[apache] case class ST_NDims(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nDims _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -183,7 +183,7 @@ case class ST_NDims(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Buffer(inputExpressions: Seq[Expression])
+private[apache] case class ST_Buffer(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.buffer),
       inferrableFunction3(Functions.buffer),
@@ -194,7 +194,7 @@ case class ST_Buffer(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_BestSRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_BestSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.bestSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -202,7 +202,7 @@ case class ST_BestSRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
+private[apache] case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.shiftLongitude _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -215,7 +215,7 @@ case class ST_ShiftLongitude(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Envelope(inputExpressions: Seq[Expression])
+private[apache] case class ST_Envelope(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.envelope _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -223,7 +223,7 @@ case class ST_Envelope(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Expand(inputExpressions: Seq[Expression])
+private[apache] case class ST_Expand(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.expand),
       inferrableFunction3(Functions.expand),
@@ -239,7 +239,7 @@ case class ST_Expand(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Length(inputExpressions: Seq[Expression])
+private[apache] case class ST_Length(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -252,7 +252,7 @@ case class ST_Length(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Length2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Length2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -265,7 +265,7 @@ case class ST_Length2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Area(inputExpressions: Seq[Expression])
+private[apache] case class ST_Area(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.area _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -278,7 +278,7 @@ case class ST_Area(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Centroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_Centroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.getCentroid _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -292,7 +292,7 @@ case class ST_Centroid(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Transform(inputExpressions: Seq[Expression])
+private[apache] case class ST_Transform(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(FunctionsGeoTools.transform),
       inferrableFunction3(FunctionsGeoTools.transform),
@@ -308,7 +308,7 @@ case class ST_Transform(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Intersection(inputExpressions: Seq[Expression])
+private[apache] case class ST_Intersection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.intersection _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -322,7 +322,7 @@ case class ST_Intersection(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_MakeValid(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeValid(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.makeValid _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -330,7 +330,7 @@ case class ST_MakeValid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsValidDetail(children: Seq[Expression])
+private[apache] case class ST_IsValidDetail(children: Seq[Expression])
     extends Expression
     with ExpectsInputTypes
     with CodegenFallback {
@@ -388,7 +388,7 @@ case class ST_IsValidDetail(children: Seq[Expression])
     .add("location", GeometryUDT, nullable = true)
 }
 
-case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction1(Functions.isValidTrajectory)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -401,7 +401,7 @@ case class ST_IsValidTrajectory(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsValid(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValid(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.isValid),
       inferrableFunction1(Functions.isValid)) {
@@ -416,7 +416,7 @@ case class ST_IsValid(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsSimple(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsSimple(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isSimple _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -434,7 +434,7 @@ case class ST_IsSimple(inputExpressions: Seq[Expression])
  *   first arg is geometry second arg is distance tolerance for the simplification(all vertices in
  *   the simplified geometry will be within this distance of the original geometry)
  */
-case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplifyPreserveTopology _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -450,7 +450,7 @@ case class ST_SimplifyPreserveTopology(inputExpressions: Seq[Expression])
  *   decimal places of the new coordinate. The last decimal place will be rounded to the nearest
  *   number.
  */
-case class ST_ReducePrecision(inputExpressions: Seq[Expression])
+private[apache] case class ST_ReducePrecision(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.reducePrecision _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -458,7 +458,7 @@ case class ST_ReducePrecision(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Simplify(inputExpressions: Seq[Expression])
+private[apache] case class ST_Simplify(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplify _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -466,7 +466,7 @@ case class ST_Simplify(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SimplifyVW(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyVW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.simplifyVW _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -474,7 +474,7 @@ case class ST_SimplifyVW(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
+private[apache] case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.simplifyPolygonHull),
       inferrableFunction3(Functions.simplifyPolygonHull)) {
@@ -484,7 +484,7 @@ case class ST_SimplifyPolygonHull(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsText(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsText(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asWKT _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -492,7 +492,7 @@ case class ST_AsText(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(Functions.asGeoJson),
       inferrableFunction2(Functions.asGeoJson)) {
@@ -502,7 +502,7 @@ case class ST_AsGeoJSON(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsBinary(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsBinary(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asWKB _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -510,7 +510,7 @@ case class ST_AsBinary(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsEWKB(inputExpressions: Seq[Expression])
     extends InferredExpression(
       (geom: Geometry) => Functions.asEWKB(geom),
       (geog: Geography) => Functions.asEWKB(geog)) {
@@ -520,7 +520,7 @@ case class ST_AsEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.asHexEWKB),
       inferrableFunction1(Functions.asHexEWKB)) {
@@ -530,7 +530,7 @@ case class ST_AsHEXEWKB(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_SRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.getSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -538,7 +538,7 @@ case class ST_SRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SetSRID(inputExpressions: Seq[Expression])
+private[apache] case class ST_SetSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.setSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -546,7 +546,7 @@ case class ST_SetSRID(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeometryType(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryType(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryType _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -562,7 +562,7 @@ case class ST_GeometryType(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_LineMerge(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineMerge(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineMerge _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -570,7 +570,7 @@ case class ST_LineMerge(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Azimuth(inputExpressions: Seq[Expression])
+private[apache] case class ST_Azimuth(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.azimuth _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -578,28 +578,31 @@ case class ST_Azimuth(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_X(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.x _) {
+private[apache] case class ST_X(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.x _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Y(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.y _) {
+private[apache] case class ST_Y(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.y _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Z(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.z _) {
+private[apache] case class ST_Z(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.z _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Zmflag(inputExpressions: Seq[Expression])
+private[apache] case class ST_Zmflag(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.zmFlag _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -607,7 +610,7 @@ case class ST_Zmflag(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_StartPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_StartPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.startPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -615,7 +618,7 @@ case class ST_StartPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Snap(inputExpressions: Seq[Expression])
+private[apache] case class ST_Snap(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.snap _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -623,7 +626,7 @@ case class ST_Snap(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Boundary(inputExpressions: Seq[Expression])
+private[apache] case class ST_Boundary(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.boundary _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -631,7 +634,7 @@ case class ST_Boundary(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumClearance(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumClearance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumClearance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -639,7 +642,7 @@ case class ST_MinimumClearance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumClearanceLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -647,7 +650,7 @@ case class ST_MinimumClearanceLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
     extends Expression
     with FoldableExpression
     with CodegenFallback {
@@ -690,7 +693,7 @@ case class ST_MinimumBoundingRadius(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
+private[apache] case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.minimumBoundingCircle _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -698,7 +701,7 @@ case class ST_MinimumBoundingCircle(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_HasZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_HasZ(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.hasZ _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -706,7 +709,7 @@ case class ST_HasZ(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_HasM(inputExpressions: Seq[Expression])
+private[apache] case class ST_HasM(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.hasM _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -714,14 +717,15 @@ case class ST_HasM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_M(inputExpressions: Seq[Expression]) extends InferredExpression(Functions.m _) {
+private[apache] case class ST_M(inputExpressions: Seq[Expression])
+    extends InferredExpression(Functions.m _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_MMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_MMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.mMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -729,7 +733,7 @@ case class ST_MMin(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_MMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.mMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -737,7 +741,7 @@ case class ST_MMax(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LineSegments(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineSegments(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.lineSegments),
       inferrableFunction1(Functions.lineSegments)) {
@@ -753,7 +757,7 @@ case class ST_LineSegments(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineSubstring(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineSubstring(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineSubString _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -768,7 +772,7 @@ case class ST_LineSubstring(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineInterpolatePoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -782,7 +786,7 @@ case class ST_LineInterpolatePoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineLocatePoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -790,7 +794,7 @@ case class ST_LineLocatePoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_EndPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_EndPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.endPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -798,7 +802,7 @@ case class ST_EndPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ExteriorRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_ExteriorRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.exteriorRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -806,7 +810,7 @@ case class ST_ExteriorRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeometryN(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometryN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -814,7 +818,7 @@ case class ST_GeometryN(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_InteriorRingN(inputExpressions: Seq[Expression])
+private[apache] case class ST_InteriorRingN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.interiorRingN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -822,7 +826,7 @@ case class ST_InteriorRingN(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Dump(inputExpressions: Seq[Expression])
+private[apache] case class ST_Dump(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dump _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -830,7 +834,7 @@ case class ST_Dump(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DumpPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_DumpPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dumpPoints _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -838,7 +842,7 @@ case class ST_DumpPoints(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsClosed(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsClosed(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isClosed _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -846,7 +850,7 @@ case class ST_IsClosed(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numInteriorRings _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -854,7 +858,7 @@ case class ST_NumInteriorRings(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numInteriorRings _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -862,7 +866,7 @@ case class ST_NumInteriorRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AddMeasure(inputExpressions: Seq[Expression])
+private[apache] case class ST_AddMeasure(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.addMeasure)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -870,7 +874,7 @@ case class ST_AddMeasure(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AddPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_AddPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.addPoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -878,7 +882,7 @@ case class ST_AddPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RemovePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_RemovePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.removePoint)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -886,7 +890,7 @@ case class ST_RemovePoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.removeRepeatedPoints),
       inferrableFunction1(Functions.removeRepeatedPoints)) {
@@ -896,7 +900,7 @@ case class ST_RemoveRepeatedPoints(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SetPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_SetPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.setPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -904,7 +908,7 @@ case class ST_SetPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ClosestPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_ClosestPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.closestPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -912,14 +916,14 @@ case class ST_ClosestPoint(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_IsPolygonCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsPolygonCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isPolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_IsRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsRing(inputExpressions: Seq[Expression])
     extends InferredExpression(ST_IsRing.isRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -927,7 +931,7 @@ case class ST_IsRing(inputExpressions: Seq[Expression])
   }
 }
 
-object ST_IsRing {
+private[apache] object ST_IsRing {
   def isRing(geom: Geometry): Option[Boolean] = {
     geom match {
       case _: LineString => Some(Functions.isRing(geom))
@@ -945,7 +949,7 @@ object ST_IsRing {
  * @param inputExpressions
  *   Geometry
  */
-case class ST_NumGeometries(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumGeometries(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numGeometries _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -959,7 +963,7 @@ case class ST_NumGeometries(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
+private[apache] case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.flipCoordinates _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -967,7 +971,7 @@ case class ST_FlipCoordinates(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SubDivide(inputExpressions: Seq[Expression])
+private[apache] case class ST_SubDivide(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.subDivide _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -975,7 +979,9 @@ case class ST_SubDivide(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator with CodegenFallback {
+private[apache] case class ST_SubDivideExplode(children: Seq[Expression])
+    extends Generator
+    with CodegenFallback {
   children.validateLength(2)
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
@@ -1010,7 +1016,7 @@ case class ST_SubDivideExplode(children: Seq[Expression]) extends Generator with
   }
 }
 
-case class ST_MakeLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakeLine(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.makeLine),
       inferrableFunction1(Functions.makeLine)) {
@@ -1020,7 +1026,7 @@ case class ST_MakeLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Perimeter(inputExpressions: Seq[Expression])
+private[apache] case class ST_Perimeter(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.perimeter),
       inferrableFunction2(Functions.perimeter),
@@ -1031,7 +1037,7 @@ case class ST_Perimeter(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Perimeter2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Perimeter2D(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.perimeter),
       inferrableFunction2(Functions.perimeter),
@@ -1042,7 +1048,7 @@ case class ST_Perimeter2D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Points(inputExpressions: Seq[Expression])
+private[apache] case class ST_Points(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.points _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1050,7 +1056,7 @@ case class ST_Points(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Polygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_Polygon(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.makepolygonWithSRID _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1058,7 +1064,7 @@ case class ST_Polygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Polygonize(inputExpressions: Seq[Expression])
+private[apache] case class ST_Polygonize(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.polygonize _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1066,7 +1072,7 @@ case class ST_Polygonize(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Project(inputExpressions: Seq[Expression])
+private[apache] case class ST_Project(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.project),
       inferrableFunction3(Functions.project)) {
@@ -1076,7 +1082,7 @@ case class ST_Project(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MakePolygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_MakePolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Functions.makePolygon)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1084,7 +1090,7 @@ case class ST_MakePolygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_MaximumInscribedCircle(children: Seq[Expression])
+private[apache] case class ST_MaximumInscribedCircle(children: Seq[Expression])
     extends Expression
     with CodegenFallback {
 
@@ -1118,7 +1124,7 @@ case class ST_MaximumInscribedCircle(children: Seq[Expression])
     .add("radius", DoubleType, nullable = false)
 }
 
-case class ST_MaxDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_MaxDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.maxDistance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1126,7 +1132,7 @@ case class ST_MaxDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_GeoHash(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeoHash(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geohash _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1139,7 +1145,7 @@ case class ST_GeoHash(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Difference(inputExpressions: Seq[Expression])
+private[apache] case class ST_Difference(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.difference _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1152,7 +1158,7 @@ case class ST_Difference(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_SymDifference(inputExpressions: Seq[Expression])
+private[apache] case class ST_SymDifference(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.symDifference _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1160,7 +1166,7 @@ case class ST_SymDifference(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_UnaryUnion(inputExpressions: Seq[Expression])
+private[apache] case class ST_UnaryUnion(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction1(Functions.unaryUnion)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1173,7 +1179,7 @@ case class ST_UnaryUnion(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Union(inputExpressions: Seq[Expression])
+private[apache] case class ST_Union(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.union),
       inferrableFunction1(Functions.union)) {
@@ -1183,7 +1189,7 @@ case class ST_Union(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Multi(inputExpressions: Seq[Expression])
+private[apache] case class ST_Multi(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.createMultiGeometryFromOneElement _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1197,7 +1203,7 @@ case class ST_Multi(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_PointOnSurface(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointOnSurface(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.pointOnSurface _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1210,7 +1216,7 @@ case class ST_PointOnSurface(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Reverse(inputExpressions: Seq[Expression])
+private[apache] case class ST_Reverse(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.reverse _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1224,7 +1230,7 @@ case class ST_Reverse(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   sequence of 2 input arguments, a geometry and a value 'n'
  */
-case class ST_PointN(inputExpressions: Seq[Expression])
+private[apache] case class ST_PointN(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.pointN _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1237,7 +1243,7 @@ case class ST_PointN(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Force_2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force_2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.force2D _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1250,7 +1256,7 @@ case class ST_Force_2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Force2D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force2D(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.force2D _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1263,7 +1269,7 @@ case class ST_Force2D(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_AsEWKT(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsEWKT(inputExpressions: Seq[Expression])
     extends InferredExpression(
       (geom: Geometry) => Functions.asEWKT(geom),
       (geog: Geography) => Functions.asEWKT(geog)) {
@@ -1273,7 +1279,7 @@ case class ST_AsEWKT(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsGML(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsGML(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asGML _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1281,7 +1287,7 @@ case class ST_AsGML(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AsKML(inputExpressions: Seq[Expression])
+private[apache] case class ST_AsKML(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.asKML _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1294,7 +1300,7 @@ case class ST_AsKML(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsEmpty(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsEmpty(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isEmpty _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1307,7 +1313,7 @@ case class ST_IsEmpty(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_XMax(inputExpressions: Seq[Expression])
+private[apache] case class ST_XMax(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.xMax _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1320,7 +1326,7 @@ case class ST_XMax(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_XMin(inputExpressions: Seq[Expression])
+private[apache] case class ST_XMin(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.xMin _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1334,7 +1340,7 @@ case class ST_XMin(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_BuildArea(inputExpressions: Seq[Expression])
+private[apache] case class ST_BuildArea(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.buildArea _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -1347,7 +1353,7 @@ case class ST_BuildArea(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Normalize(inputExpressions: Seq[Expression])
+private[apache] case class ST_Normalize(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.normalize _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
@@ -1360,7 +1366,7 @@ case class ST_Normalize(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.lineFromMultiPoint _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1374,7 +1380,7 @@ case class ST_LineFromMultiPoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Split(inputExpressions: Seq[Expression])
+private[apache] case class ST_Split(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.split _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1382,7 +1388,7 @@ case class ST_Split(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_S2CellIDs(inputExpressions: Seq[Expression])
+private[apache] case class ST_S2CellIDs(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.s2CellIDs _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1390,14 +1396,14 @@ case class ST_S2CellIDs(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_S2ToGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_S2ToGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.s2ToGeom _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_H3CellIDs(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3CellIDs(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3CellIDs _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1405,7 +1411,7 @@ case class ST_H3CellIDs(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3CellDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3CellDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3CellDistance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1413,7 +1419,7 @@ case class ST_H3CellDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3KRing(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3KRing(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3KRing _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1421,7 +1427,7 @@ case class ST_H3KRing(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_H3ToGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_H3ToGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.h3ToGeom _)
     with FoldableExpression {
 
@@ -1430,7 +1436,7 @@ case class ST_H3ToGeom(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_CollectionExtract(inputExpressions: Seq[Expression])
+private[apache] case class ST_CollectionExtract(inputExpressions: Seq[Expression])
     extends InferredExpression(InferrableFunction.allowRightNull(Functions.collectionExtract)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1446,7 +1452,7 @@ case class ST_CollectionExtract(inputExpressions: Seq[Expression])
  * @param inputExpressions
  *   Geometry
  */
-case class ST_GeometricMedian(inputExpressions: Seq[Expression])
+private[apache] case class ST_GeometricMedian(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction4(Functions.geometricMedian))
     with FoldableExpression {
 
@@ -1455,7 +1461,7 @@ case class ST_GeometricMedian(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DistanceSphere(inputExpressions: Seq[Expression])
+private[apache] case class ST_DistanceSphere(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Haversine.distance),
       inferrableFunction3(Haversine.distance)) {
@@ -1465,7 +1471,7 @@ case class ST_DistanceSphere(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.distance _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1473,7 +1479,7 @@ case class ST_DistanceSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.area _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1481,7 +1487,7 @@ case class ST_AreaSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
+private[apache] case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
     extends InferredExpression(Spheroid.length _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1489,7 +1495,7 @@ case class ST_LengthSpheroid(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LocateAlong(inputExpressions: Seq[Expression])
+private[apache] case class ST_LocateAlong(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.locateAlong),
       inferrableFunction2(Functions.locateAlong)) {
@@ -1499,7 +1505,7 @@ case class ST_LocateAlong(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_LongestLine(inputExpressions: Seq[Expression])
+private[apache] case class ST_LongestLine(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.longestLine _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1507,14 +1513,14 @@ case class ST_LongestLine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_NumPoints(inputExpressions: Seq[Expression])
+private[apache] case class ST_NumPoints(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.numPoints _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Force3D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3D(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3D)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1522,7 +1528,7 @@ case class ST_Force3D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force3DZ(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3DZ(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3D)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1530,7 +1536,7 @@ case class ST_Force3DZ(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force3DM(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force3DM(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.force3DM)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1538,7 +1544,7 @@ case class ST_Force3DM(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Force4D(inputExpressions: Seq[Expression])
+private[apache] case class ST_Force4D(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.force4D),
       inferrableFunction1(Functions.force4D)) {
@@ -1548,7 +1554,7 @@ case class ST_Force4D(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ForceCollection(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForceCollection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forceCollection _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1556,21 +1562,21 @@ case class ST_ForceCollection(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_ForcePolygonCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForcePolygonCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_ForceRHR(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForceRHR(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long)
+private[apache] case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long)
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes
@@ -1622,28 +1628,28 @@ case class ST_GeneratePoints(inputExpressions: Seq[Expression], randomSeed: Long
   }
 }
 
-case class ST_NRings(inputExpressions: Seq[Expression])
+private[apache] case class ST_NRings(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nRings _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_IsPolygonCCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsPolygonCCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isPolygonCCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_ForcePolygonCCW(inputExpressions: Seq[Expression])
+private[apache] case class ST_ForcePolygonCCW(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.forcePolygonCCW _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_Translate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Translate(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction4(Functions.translate))
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1651,7 +1657,7 @@ case class ST_Translate(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
+private[apache] case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.triangulatePolygon _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1659,7 +1665,7 @@ case class ST_TriangulatePolygon(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
+private[apache] case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
     extends InferredExpression(nullTolerantInferrableFunction3(FunctionsGeoTools.voronoiPolygons))
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1667,7 +1673,7 @@ case class ST_VoronoiPolygons(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_FrechetDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_FrechetDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.frechetDistance _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1675,7 +1681,7 @@ case class ST_FrechetDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Affine(inputExpressions: Seq[Expression])
+private[apache] case class ST_Affine(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction13(Functions.affine),
       inferrableFunction7(Functions.affine)) {
@@ -1684,7 +1690,7 @@ case class ST_Affine(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Dimension(inputExpressions: Seq[Expression])
+private[apache] case class ST_Dimension(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.dimension _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1692,14 +1698,14 @@ case class ST_Dimension(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_BoundingDiagonal(inputExpressions: Seq[Expression])
+private[apache] case class ST_BoundingDiagonal(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.boundingDiagonal _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
+private[apache] case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.hausdorffDistance),
       inferrableFunction2(Functions.hausdorffDistance)) {
@@ -1708,7 +1714,7 @@ case class ST_HausdorffDistance(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Angle(inputExpressions: Seq[Expression])
+private[apache] case class ST_Angle(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(Functions.angle _),
       inferrableFunction3(Functions.angle _),
@@ -1719,7 +1725,7 @@ case class ST_Angle(inputExpressions: Seq[Expression])
   }
 }
 
-case class GeometryType(inputExpressions: Seq[Expression])
+private[apache] case class GeometryType(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.geometryTypeWithMeasured _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1727,7 +1733,7 @@ case class GeometryType(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Degrees(inputExpressions: Seq[Expression])
+private[apache] case class ST_Degrees(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.degrees _)
     with FoldableExpression {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -1735,7 +1741,7 @@ case class ST_Degrees(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
+private[apache] case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.delaunayTriangle),
       inferrableFunction2(Functions.delaunayTriangle),
@@ -1751,7 +1757,7 @@ case class ST_DelaunayTriangles(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_CoordDim(inputExpressions: Seq[Expression])
+private[apache] case class ST_CoordDim(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.nDims _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
@@ -1763,7 +1769,7 @@ case class ST_CoordDim(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_IsCollection(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsCollection(inputExpressions: Seq[Expression])
     extends InferredExpression(Functions.isCollection _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
@@ -1781,7 +1787,7 @@ case class ST_IsCollection(inputExpressions: Seq[Expression])
  * @return
  *   A string describing the validity of the geometry.
  */
-case class ST_IsValidReason(inputExpressions: Seq[Expression])
+private[apache] case class ST_IsValidReason(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.isValidReason),
       inferrableFunction1(Functions.isValidReason)) {
@@ -1790,14 +1796,14 @@ case class ST_IsValidReason(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_Scale(inputExpressions: Seq[Expression])
+private[apache] case class ST_Scale(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(Functions.scale)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_ScaleGeom(inputExpressions: Seq[Expression])
+private[apache] case class ST_ScaleGeom(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Functions.scaleGeom),
       inferrableFunction2(Functions.scaleGeom)) {
@@ -1806,21 +1812,21 @@ case class ST_ScaleGeom(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_RotateX(inputExpressions: Seq[Expression])
+private[apache] case class ST_RotateX(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.rotateX)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_RotateY(inputExpressions: Seq[Expression])
+private[apache] case class ST_RotateY(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.rotateY)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ST_Rotate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Rotate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(Functions.rotate),
       inferrableFunction3(Functions.rotate),
@@ -1830,13 +1836,13 @@ case class ST_Rotate(inputExpressions: Seq[Expression])
     copy(inputExpressions = newChildren)
 }
 
-case class ST_InterpolatePoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_InterpolatePoint(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Functions.interpolatePoint)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) =
     copy(inputExpressions = newChildren)
 }
 
-case class ExpandAddress(address: Expression)
+private[apache] case class ExpandAddress(address: Expression)
     extends UnaryExpression
     with ImplicitCastInputTypes
     with CodegenFallback
@@ -1899,7 +1905,7 @@ case class ExpandAddress(address: Expression)
     ExpandAddress(newChild)
 }
 
-case class ParseAddress(address: Expression)
+private[apache] case class ParseAddress(address: Expression)
     extends UnaryExpression
     with ImplicitCastInputTypes
     with CodegenFallback

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.types._
 
 case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunction {
 
-  override def dataType: DataType = StructType(
-    Seq(StructField("isCore", BooleanType), StructField("cluster", LongType)))
+  override def dataType: DataType =
+    StructType(Seq(StructField("isCore", BooleanType), StructField("cluster", LongType)))
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(GeometryUDT, DoubleType, IntegerType, BooleanType)
@@ -50,7 +50,7 @@ case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunctio
       !dataframe.columns.contains("__cluster"),
       "__cluster is a  reserved name by the dbscan algorithm. Please rename the columns before calling the ST_DBSCAN function.")
 
-    dbscan(
+    val ret = dbscan(
       dataframe,
       getScalarValue[Double](1, "epsilon"),
       getScalarValue[Int](2, "minPts"),
@@ -61,6 +61,9 @@ case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunctio
       "__cluster")
       .withColumn(getResultName(resultAttrs), struct(col("__isCore"), col("__cluster")))
       .drop("__isCore", "__cluster")
+
+    ret
+
   }
 }
 

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/GeoStatsFunctions.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.sedona_sql.UDT.GeometryUDT
 import org.apache.spark.sql.types._
 
-case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_DBSCAN(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType =
     StructType(Seq(StructField("isCore", BooleanType), StructField("cluster", LongType)))
@@ -67,7 +68,8 @@ case class ST_DBSCAN(children: Seq[Expression]) extends DataframePhysicalFunctio
   }
 }
 
-case class ST_LocalOutlierFactor(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_LocalOutlierFactor(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType = DoubleType
 
@@ -90,7 +92,8 @@ case class ST_LocalOutlierFactor(children: Seq[Expression]) extends DataframePhy
   }
 }
 
-case class ST_GLocal(children: Seq[Expression]) extends DataframePhysicalFunction {
+private[apache] case class ST_GLocal(children: Seq[Expression])
+    extends DataframePhysicalFunction {
 
   override def dataType: DataType = StructType(
     Seq(
@@ -129,7 +132,7 @@ case class ST_GLocal(children: Seq[Expression]) extends DataframePhysicalFunctio
   }
 }
 
-case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
+private[apache] case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
     extends DataframePhysicalFunction {
   override def dataType: DataType = ArrayType(
     StructType(
@@ -162,7 +165,7 @@ case class ST_BinaryDistanceBandColumn(children: Seq[Expression])
   }
 }
 
-case class ST_WeightedDistanceBandColumn(children: Seq[Expression])
+private[apache] case class ST_WeightedDistanceBandColumn(children: Seq[Expression])
     extends DataframePhysicalFunction {
 
   override def dataType: DataType = ArrayType(

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/Predicates.scala
@@ -78,7 +78,7 @@ abstract class ST_Predicate
  *
  * @param inputExpressions
  */
-case class ST_Contains(inputExpressions: Seq[Expression])
+private[apache] case class ST_Contains(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -96,7 +96,7 @@ case class ST_Contains(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Intersects(inputExpressions: Seq[Expression])
+private[apache] case class ST_Intersects(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -114,7 +114,7 @@ case class ST_Intersects(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Within(inputExpressions: Seq[Expression])
+private[apache] case class ST_Within(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -132,7 +132,7 @@ case class ST_Within(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Covers(inputExpressions: Seq[Expression])
+private[apache] case class ST_Covers(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -150,7 +150,7 @@ case class ST_Covers(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_CoveredBy(inputExpressions: Seq[Expression])
+private[apache] case class ST_CoveredBy(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -168,7 +168,7 @@ case class ST_CoveredBy(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Crosses(inputExpressions: Seq[Expression])
+private[apache] case class ST_Crosses(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -186,7 +186,7 @@ case class ST_Crosses(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Overlaps(inputExpressions: Seq[Expression])
+private[apache] case class ST_Overlaps(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -204,7 +204,7 @@ case class ST_Overlaps(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Touches(inputExpressions: Seq[Expression])
+private[apache] case class ST_Touches(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -217,7 +217,7 @@ case class ST_Touches(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_Relate(inputExpressions: Seq[Expression])
+private[apache] case class ST_Relate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.relate),
       inferrableFunction2(Predicates.relate)) {
@@ -227,7 +227,7 @@ case class ST_Relate(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_RelateMatch(inputExpressions: Seq[Expression])
+private[apache] case class ST_RelateMatch(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction2(Predicates.relateMatch)) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
@@ -240,7 +240,7 @@ case class ST_RelateMatch(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Equals(inputExpressions: Seq[Expression])
+private[apache] case class ST_Equals(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -259,7 +259,7 @@ case class ST_Equals(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_Disjoint(inputExpressions: Seq[Expression])
+private[apache] case class ST_Disjoint(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -277,7 +277,7 @@ case class ST_Disjoint(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_OrderingEquals(inputExpressions: Seq[Expression])
+private[apache] case class ST_OrderingEquals(inputExpressions: Seq[Expression])
     extends ST_Predicate
     with CodegenFallback {
 
@@ -290,7 +290,7 @@ case class ST_OrderingEquals(inputExpressions: Seq[Expression])
   }
 }
 
-case class ST_DWithin(inputExpressions: Seq[Expression])
+private[apache] case class ST_DWithin(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.dWithin),
       inferrableFunction4(Predicates.dWithin)) {
@@ -306,7 +306,7 @@ case class ST_DWithin(inputExpressions: Seq[Expression])
  *
  * @param inputExpressions
  */
-case class ST_KNN(inputExpressions: Seq[Expression])
+private[apache] case class ST_KNN(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(Predicates.knn),
       inferrableFunction4(Predicates.knn)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/ST_Collect.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/collect/ST_Collect.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.sedona_sql.expressions.{InferredExpression, SerdeAwa
 import org.apache.spark.sql.types.{ArrayType, _}
 import org.locationtech.jts.geom.Geometry
 
-case class ST_Collect(inputExpressions: Seq[Expression])
+private[apache] case class ST_Collect(inputExpressions: Seq[Expression])
     extends Expression
     with SerdeAware
     with CodegenFallback {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/GeometryFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/GeometryFunctions.scala
@@ -24,21 +24,21 @@ import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 
-case class RS_ConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class RS_ConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(GeometryFunctions.convexHull _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Envelope(inputExpressions: Seq[Expression])
+private[apache] case class RS_Envelope(inputExpressions: Seq[Expression])
     extends InferredExpression(GeometryFunctions.envelope _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_MinConvexHull(inputExpressions: Seq[Expression])
+private[apache] case class RS_MinConvexHull(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(GeometryFunctions.minConvexHull),
       inferrableFunction1(GeometryFunctions.minConvexHull)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/IO.scala
@@ -20,19 +20,12 @@ package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, UnsafeArrayData}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.sedona_sql.expressions.UserDataGenerator
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 
-import java.awt.Color
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
-import java.util.Base64
-import javax.imageio.ImageIO
-
-case class RS_Array(inputExpressions: Seq[Expression])
+private[apache] case class RS_Array(inputExpressions: Seq[Expression])
     extends Expression
     with ImplicitCastInputTypes
     with CodegenFallback

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctionEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctionEditors.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetValues(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetValues(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction8(PixelFunctionEditors.setValues),
       inferrableFunction7(PixelFunctionEditors.setValues),
@@ -36,7 +36,7 @@ case class RS_SetValues(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SetValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction5(PixelFunctionEditors.setValue),
       inferrableFunction4(PixelFunctionEditors.setValue)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/PixelFunctions.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.{AbstractDataType, ArrayType, DataType, Double
 
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
-case class RS_Value(inputExpressions: Seq[Expression])
+private[apache] case class RS_Value(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(PixelFunctions.value),
       inferrableFunction3(PixelFunctions.value),
@@ -43,14 +43,14 @@ case class RS_Value(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_PixelAsPoint(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPoint(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsPoint _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -91,14 +91,14 @@ case class RS_PixelAsPoints(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_PixelAsPolygon(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPolygon(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsPolygon _) {
   protected def withNewChildrenInternal(newChilren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChilren)
   }
 }
 
-case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -140,14 +140,14 @@ case class RS_PixelAsPolygons(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_PixelAsCentroid(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsCentroid(inputExpressions: Seq[Expression])
     extends InferredExpression(PixelFunctions.getPixelAsCentroid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
+private[apache] case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -189,7 +189,7 @@ case class RS_PixelAsCentroids(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT, IntegerType)
 }
 
-case class RS_Values(inputExpressions: Seq[Expression])
+private[apache] case class RS_Values(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(PixelFunctions.values),
       inferrableFunction3(PixelFunctions.values),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterAccessors.scala
@@ -24,63 +24,63 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_NumBands(inputExpressions: Seq[Expression])
+private[apache] case class RS_NumBands(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.numBands _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SRID(inputExpressions: Seq[Expression])
+private[apache] case class RS_SRID(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.srid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Width(inputExpressions: Seq[Expression])
+private[apache] case class RS_Width(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWidth _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_UpperLeftX(inputExpressions: Seq[Expression])
+private[apache] case class RS_UpperLeftX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getUpperLeftX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_UpperLeftY(inputExpressions: Seq[Expression])
+private[apache] case class RS_UpperLeftY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getUpperLeftY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Height(inputExpressions: Seq[Expression])
+private[apache] case class RS_Height(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getHeight _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_ScaleX(inputExpressions: Seq[Expression])
+private[apache] case class RS_ScaleX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getScaleX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_ScaleY(inputExpressions: Seq[Expression])
+private[apache] case class RS_ScaleY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getScaleY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_GeoReference(inputExpressions: Seq[Expression])
+private[apache] case class RS_GeoReference(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterAccessors.getGeoReference),
       inferrableFunction1(RasterAccessors.getGeoReference)) {
@@ -89,49 +89,49 @@ case class RS_GeoReference(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Rotation(inputExpressions: Seq[Expression])
+private[apache] case class RS_Rotation(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getRotation _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SkewX(inputExpressions: Seq[Expression])
+private[apache] case class RS_SkewX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getSkewX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SkewY(inputExpressions: Seq[Expression])
+private[apache] case class RS_SkewY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getSkewY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoordX(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoordX(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoordX _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoordY(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoordY(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoordY _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_RasterToWorldCoord(inputExpressions: Seq[Expression])
+private[apache] case class RS_RasterToWorldCoord(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterAccessors.getWorldCoord _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoord),
       inferrableFunction2(RasterAccessors.getGridCoord)) {
@@ -140,7 +140,7 @@ case class RS_WorldToRasterCoord(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoordX),
       inferrableFunction2(RasterAccessors.getGridCoordX)) {
@@ -149,7 +149,7 @@ case class RS_WorldToRasterCoordX(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_WorldToRasterCoordY(inputExpressions: Seq[Expression])
+private[apache] case class RS_WorldToRasterCoordY(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterAccessors.getGridCoordY),
       inferrableFunction2(RasterAccessors.getGridCoordY)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandAccessors.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputE
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.geotools.coverage.grid.GridCoverage2D
 
-case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getBandNoDataValue),
       inferrableFunction1(RasterBandAccessors.getBandNoDataValue)) {
@@ -38,7 +38,7 @@ case class RS_BandNoDataValue(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Count(inputExpressions: Seq[Expression])
+private[apache] case class RS_Count(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getCount),
       inferrableFunction1(RasterBandAccessors.getCount),
@@ -48,7 +48,7 @@ case class RS_Count(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ZonalStats(inputExpressions: Seq[Expression])
+private[apache] case class RS_ZonalStats(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction7(RasterBandAccessors.getZonalStats),
       inferrableFunction6(RasterBandAccessors.getZonalStats),
@@ -60,7 +60,7 @@ case class RS_ZonalStats(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SummaryStats(inputExpressions: Seq[Expression])
+private[apache] case class RS_SummaryStats(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getSummaryStats),
       inferrableFunction3(RasterBandAccessors.getSummaryStats),
@@ -70,7 +70,7 @@ case class RS_SummaryStats(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Band(inputExpressions: Seq[Expression])
+private[apache] case class RS_Band(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterBandAccessors.getBand _) {
 
   override def evalWithoutSerialization(input: InternalRow): Any = {
@@ -93,7 +93,7 @@ case class RS_Band(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_BandPixelType(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandPixelType(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.getBandType),
       inferrableFunction1(RasterBandAccessors.getBandType)) {
@@ -102,7 +102,7 @@ case class RS_BandPixelType(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_BandIsNoData(inputExpressions: Seq[Expression])
+private[apache] case class RS_BandIsNoData(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandAccessors.bandIsNoData),
       inferrableFunction1(RasterBandAccessors.bandIsNoData)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterBandEditors.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.setBandNoDataValue),
       inferrableFunction3(RasterBandEditors.setBandNoDataValue),
@@ -34,7 +34,7 @@ case class RS_SetBandNoDataValue(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AddBand(inputExpressions: Seq[Expression])
+private[apache] case class RS_AddBand(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction4(RasterBandEditors.addBand),
       inferrableFunction3(RasterBandEditors.addBand),
@@ -44,7 +44,7 @@ case class RS_AddBand(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Union(inputExpressions: Seq[Expression])
+private[apache] case class RS_Union(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterBandEditors.rasterUnion),
       inferrableFunction3(RasterBandEditors.rasterUnion),
@@ -57,7 +57,7 @@ case class RS_Union(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Clip(inputExpressions: Seq[Expression])
+private[apache] case class RS_Clip(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction7(RasterBandEditors.clip),
       inferrableFunction6(RasterBandEditors.clip),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterConstructors.scala
@@ -19,7 +19,6 @@
 package org.apache.spark.sql.sedona_sql.expressions.raster
 
 import org.apache.sedona.common.raster.{RasterConstructors, RasterConstructorsForTesting}
-import org.apache.sedona.sql.utils.RasterSerializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{CreateArray, Expression, Generator, Literal}
@@ -29,9 +28,9 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.{RasterEnhancer, RasterInputExpressionEnhancer}
-import org.apache.spark.sql.types.{ArrayType, BooleanType, Decimal, IntegerType, NullType, StructType}
+import org.apache.spark.sql.types._
 
-case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.fromArcInfoAsciiGrid _) {
   override def foldable: Boolean = false
 
@@ -40,7 +39,7 @@ case class RS_FromArcInfoAsciiGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterConstructors.asRaster),
       inferrableFunction4(RasterConstructors.asRaster),
@@ -52,7 +51,7 @@ case class RS_AsRaster(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.fromGeoTiff _) {
 
   override def foldable: Boolean = false
@@ -62,7 +61,7 @@ case class RS_FromGeoTiff(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction6(RasterConstructors.makeEmptyRaster),
       inferrableFunction7(RasterConstructors.makeEmptyRaster),
@@ -76,21 +75,21 @@ case class RS_MakeEmptyRaster(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_MakeRaster(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeRaster(inputExpressions: Seq[Expression])
     extends InferredExpression(inferrableFunction3(RasterConstructors.makeNonEmptyRaster)) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_MakeRasterForTesting(inputExpressions: Seq[Expression])
+private[apache] case class RS_MakeRasterForTesting(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructorsForTesting.makeRasterForTesting _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Tile(inputExpressions: Seq[Expression])
+private[apache] case class RS_Tile(inputExpressions: Seq[Expression])
     extends InferredExpression(
       nullTolerantInferrableFunction3(RasterConstructors.rsTile),
       nullTolerantInferrableFunction4(RasterConstructors.rsTile),
@@ -101,7 +100,9 @@ case class RS_Tile(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_TileExplode(children: Seq[Expression]) extends Generator with CodegenFallback {
+private[apache] case class RS_TileExplode(children: Seq[Expression])
+    extends Generator
+    with CodegenFallback {
   private val arguments = RS_TileExplode.arguments(children)
 
   override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
@@ -205,7 +206,7 @@ object RS_TileExplode {
   }
 }
 
-case class RS_FromNetCDF(inputExpressions: Seq[Expression])
+private[apache] case class RS_FromNetCDF(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterConstructors.fromNetCDF),
       inferrableFunction4(RasterConstructors.fromNetCDF)) {
@@ -216,7 +217,7 @@ case class RS_FromNetCDF(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_NetCDFInfo(inputExpressions: Seq[Expression])
+private[apache] case class RS_NetCDFInfo(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterConstructors.getRecordInfo _) {
 
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterEditors.scala
@@ -24,14 +24,14 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_SetSRID(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetSRID(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.setSrid _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_SetGeoReference(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetGeoReference(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterEditors.setGeoReference),
       inferrableFunction3(RasterEditors.setGeoReference),
@@ -41,14 +41,14 @@ case class RS_SetGeoReference(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_SetPixelType(inputExpressions: Seq[Expression])
+private[apache] case class RS_SetPixelType(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.setPixelType _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Resample(inputExpressions: Seq[Expression])
+private[apache] case class RS_Resample(inputExpressions: Seq[Expression])
     extends InferredExpression(
       nullTolerantInferrableFunction4(RasterEditors.resample),
       nullTolerantInferrableFunction5(RasterEditors.resample),
@@ -58,7 +58,7 @@ case class RS_Resample(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_NormalizeAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_NormalizeAll(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterEditors.normalizeAll),
       inferrableFunction3(RasterEditors.normalizeAll),
@@ -71,14 +71,14 @@ case class RS_NormalizeAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ReprojectMatch(inputExpressions: Seq[Expression])
+private[apache] case class RS_ReprojectMatch(inputExpressions: Seq[Expression])
     extends InferredExpression(RasterEditors.reprojectMatch _) {
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]) = {
     copy(inputExpressions = newChildren)
   }
 }
 
-case class RS_Interpolate(inputExpressions: Seq[Expression])
+private[apache] case class RS_Interpolate(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterEditors.interpolate),
       inferrableFunction2(RasterEditors.interpolate),

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterFunctions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.sedona_sql.expressions.implicits.InputExpressionEnha
 import org.apache.spark.sql.sedona_sql.expressions.raster.implicits.RasterInputExpressionEnhancer
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType, DoubleType, IntegerType, StructField, StructType}
 
-case class RS_Metadata(inputExpressions: Seq[Expression])
+private[apache] case class RS_Metadata(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -86,7 +86,7 @@ case class RS_Metadata(inputExpressions: Seq[Expression])
   override def inputTypes: Seq[AbstractDataType] = Seq(RasterUDT)
 }
 
-case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -150,7 +150,7 @@ case class RS_SummaryStatsAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
+private[apache] case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {
@@ -235,7 +235,7 @@ case class RS_ZonalStatsAll(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_GeoTransform(inputExpressions: Seq[Expression])
+private[apache] case class RS_GeoTransform(inputExpressions: Seq[Expression])
     extends Expression
     with CodegenFallback
     with ExpectsInputTypes {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterOutputs.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.sedona_sql.expressions.InferrableFunctionConverter._
 import org.apache.spark.sql.sedona_sql.expressions.InferrableRasterTypes._
 import org.apache.spark.sql.sedona_sql.expressions.InferredExpression
 
-case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterOutputs.asGeoTiff),
       inferrableFunction1(RasterOutputs.asGeoTiff)) {
@@ -33,7 +33,7 @@ case class RS_AsGeoTiff(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsArcGrid(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsArcGrid(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterOutputs.asArcGrid),
       inferrableFunction1(RasterOutputs.asArcGrid)) {
@@ -42,7 +42,7 @@ case class RS_AsArcGrid(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsPNG(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsPNG(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterOutputs.asPNG),
       inferrableFunction2(RasterOutputs.asPNG)) {
@@ -51,7 +51,7 @@ case class RS_AsPNG(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsBase64(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsBase64(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction1(RasterOutputs.asBase64),
       inferrableFunction2(RasterOutputs.asBase64)) {
@@ -60,7 +60,7 @@ case class RS_AsBase64(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsMatrix(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsMatrix(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction3(RasterOutputs.asMatrix),
       inferrableFunction2(RasterOutputs.asMatrix),
@@ -70,7 +70,7 @@ case class RS_AsMatrix(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_AsImage(inputExpressions: Seq[Expression])
+private[apache] case class RS_AsImage(inputExpressions: Seq[Expression])
     extends InferredExpression(
       inferrableFunction2(RasterOutputs.createHTMLString),
       inferrableFunction1(RasterOutputs.createHTMLString)) {

--- a/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
+++ b/spark/common/src/main/scala/org/apache/spark/sql/sedona_sql/expressions/raster/RasterPredicates.scala
@@ -99,7 +99,7 @@ abstract class RS_Predicate
   def evalRasters(leftRaster: GridCoverage2D, rightRaster: GridCoverage2D): Boolean
 }
 
-case class RS_Intersects(inputExpressions: Seq[Expression])
+private[apache] case class RS_Intersects(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 
@@ -118,7 +118,7 @@ case class RS_Intersects(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Contains(inputExpressions: Seq[Expression])
+private[apache] case class RS_Contains(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 
@@ -137,7 +137,7 @@ case class RS_Contains(inputExpressions: Seq[Expression])
   }
 }
 
-case class RS_Within(inputExpressions: Seq[Expression])
+private[apache] case class RS_Within(inputExpressions: Seq[Expression])
     extends RS_Predicate
     with CodegenFallback {
 

--- a/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -40,7 +40,6 @@ import org.apache.spark.sql.types._
 import org.json4s.{DefaultFormats, Extraction, JValue}
 import org.json4s.jackson.JsonMethods.parse
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.io.WKBWriter
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -340,7 +339,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         (row: SpecializedGetters, ordinal: Int) => {
           val serializedGeometry = row.getBinary(ordinal)
           val geom = GeometryUDT.deserialize(serializedGeometry)
-          val wkbWriter = new WKBWriter(GeomUtils.getDimension(geom))
+          val wkbWriter = GeomUtils.createWKBWriter(GeomUtils.getDimension(geom))
           recordConsumer.addBinary(Binary.fromReusedByteArray(wkbWriter.write(geom)))
           if (geometryColumnInfo != null) {
             geometryColumnInfo.update(geom)

--- a/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-3.5/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -41,7 +41,6 @@ import org.json4s.{DefaultFormats, Extraction, JValue}
 import org.json4s.jackson.compactJson
 import org.json4s.jackson.JsonMethods.parse
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.io.WKBWriter
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -341,7 +340,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         (row: SpecializedGetters, ordinal: Int) => {
           val serializedGeometry = row.getBinary(ordinal)
           val geom = GeometryUDT.deserialize(serializedGeometry)
-          val wkbWriter = new WKBWriter(GeomUtils.getDimension(geom))
+          val wkbWriter = GeomUtils.createWKBWriter(GeomUtils.getDimension(geom))
           recordConsumer.addBinary(Binary.fromReusedByteArray(wkbWriter.write(geom)))
           if (geometryColumnInfo != null) {
             geometryColumnInfo.update(geom)

--- a/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/spark-3.5/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -42,6 +42,7 @@ import org.locationtech.jts.io.WKTReader
 import org.scalatest.BeforeAndAfterAll
 
 import java.io.File
+import java.nio.ByteOrder
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicLong
 import java.time.LocalDateTime
@@ -85,6 +86,15 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
         newrows
           .getAs[Geometry]("geometry")
           .toString == "MULTIPOLYGON (((180 -16.067132663642447, 180 -16.555216566639196, 179.36414266196414 -16.801354076946883, 178.72505936299711 -17.01204167436804, 178.59683859511713 -16.639150000000004, 179.0966093629971 -16.433984277547403, 179.4135093629971 -16.379054277547404, 180 -16.067132663642447)), ((178.12557 -17.50481, 178.3736 -17.33992, 178.71806 -17.62846, 178.55271 -18.15059, 177.93266000000003 -18.28799, 177.38146 -18.16432, 177.28504 -17.72465, 177.67087 -17.381140000000002, 178.12557 -17.50481)), ((-179.79332010904864 -16.020882256741224, -179.9173693847653 -16.501783135649397, -180 -16.555216566639196, -180 -16.067132663642447, -179.79332010904864 -16.020882256741224)))")
+      // The endianness of the WKB should be system native.
+      val df2Binary = sparkSession.read.parquet(geoparquetoutputlocation + "/gp_sample1.parquet")
+      df2Binary.collect().foreach { row =>
+        val wkb = row.getAs[Array[Byte]]("geometry")
+        wkb(0) match {
+          case 0x00 => assert(ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN)
+          case 0x01 => assert(ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN)
+        }
+      }
     }
     it("GEOPARQUET Test example2 i.e. naturalearth_citie dataset's Read and Write") {
       val df = sparkSession.read.format("geoparquet").load(geoparquetdatalocation2)

--- a/spark/spark-4.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
+++ b/spark/spark-4.0/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/GeoParquetWriteSupport.scala
@@ -41,7 +41,6 @@ import org.json4s.{DefaultFormats, Extraction, JValue}
 import org.json4s.jackson.compactJson
 import org.json4s.jackson.JsonMethods.parse
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.io.WKBWriter
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -341,7 +340,7 @@ class GeoParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
         (row: SpecializedGetters, ordinal: Int) => {
           val serializedGeometry = row.getBinary(ordinal)
           val geom = GeometryUDT.deserialize(serializedGeometry)
-          val wkbWriter = new WKBWriter(GeomUtils.getDimension(geom))
+          val wkbWriter = GeomUtils.createWKBWriter(GeomUtils.getDimension(geom))
           recordConsumer.addBinary(Binary.fromReusedByteArray(wkbWriter.write(geom)))
           if (geometryColumnInfo != null) {
             geometryColumnInfo.update(geom)

--- a/spark/spark-4.0/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
+++ b/spark/spark-4.0/src/test/scala/org/apache/sedona/sql/geoparquetIOTests.scala
@@ -42,6 +42,7 @@ import org.locationtech.jts.io.WKTReader
 import org.scalatest.BeforeAndAfterAll
 
 import java.io.File
+import java.nio.ByteOrder
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicLong
 import java.time.LocalDateTime
@@ -85,6 +86,15 @@ class geoparquetIOTests extends TestBaseScala with BeforeAndAfterAll {
         newrows
           .getAs[Geometry]("geometry")
           .toString == "MULTIPOLYGON (((180 -16.067132663642447, 180 -16.555216566639196, 179.36414266196414 -16.801354076946883, 178.72505936299711 -17.01204167436804, 178.59683859511713 -16.639150000000004, 179.0966093629971 -16.433984277547403, 179.4135093629971 -16.379054277547404, 180 -16.067132663642447)), ((178.12557 -17.50481, 178.3736 -17.33992, 178.71806 -17.62846, 178.55271 -18.15059, 177.93266000000003 -18.28799, 177.38146 -18.16432, 177.28504 -17.72465, 177.67087 -17.381140000000002, 178.12557 -17.50481)), ((-179.79332010904864 -16.020882256741224, -179.9173693847653 -16.501783135649397, -180 -16.555216566639196, -180 -16.067132663642447, -179.79332010904864 -16.020882256741224)))")
+      // The endianness of the WKB should be system native.
+      val df2Binary = sparkSession.read.parquet(geoparquetoutputlocation + "/gp_sample1.parquet")
+      df2Binary.collect().foreach { row =>
+        val wkb = row.getAs[Array[Byte]]("geometry")
+        wkb(0) match {
+          case 0x00 => assert(ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN)
+          case 0x01 => assert(ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN)
+        }
+      }
     }
     it("GEOPARQUET Test example2 i.e. naturalearth_citie dataset's Read and Write") {
       val df = sparkSession.read.format("geoparquet").load(geoparquetdatalocation2)


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read the [Contributor Rules](https://sedona.apache.org/latest/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest/community/develop/)

## Is this PR related to a ticket?

- Yes, and the PR name follows the format `[GH-XXX] my subject`. Closes #2176 

## What changes were proposed in this PR?

* Refactored code to always use `GeomUtils.createWKBWriter`, which returns a WKB writer using the native byte order.
* Removed redundant WKB serde in some snowflake UDFs.

## How was this patch tested?

* Passing existing tests
* Add a new test to verify that the GeoParquet files written by sedona has native byte order

## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the documentation. However, this change might be breaking, so we'd better add this to the release note of 1.8.0.
