### PR TITLE
Fix pre-commit failures after apache upstream sync

### DIFF
--- a/.github/workflows/databricks-tester.yml
+++ b/.github/workflows/databricks-tester.yml
@@ -62,15 +62,15 @@ jobs:
       sedona-version: ${{ steps.build-info.outputs.sedona-version }}
       geotools-path: ${{ steps.build-info.outputs.geotools-path }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -105,7 +105,7 @@ jobs:
           echo "Sedona Version: ${SEDONA_VERSION}"
           echo "GeoTools JAR: ${GEOTOOLS_JAR_PATH}"
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: sedona-jars-${{ matrix.spark }}-${{ matrix.scala }}
           path: databricks-artifacts/tmp/
@@ -131,16 +131,16 @@ jobs:
             scala: '2.13'
             runtime: '17.3.x-scala2.13-photon'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sedona-jars-${{ matrix.spark }}-${{ matrix.scala }}
           path: databricks-artifacts/tmp/
@@ -187,10 +187,10 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
       - name: Install uv

--- a/.github/workflows/snowflake-tester.yml
+++ b/.github/workflows/snowflake-tester.yml
@@ -41,15 +41,15 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'zulu'
           java-version: '11'
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,12 +301,12 @@ repos:
       - id: forbid-tabs
         name: run forbid-tabs
         description: check the codebase for tabs
-        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
       - id: remove-tabs
         name: run remove-tabs
         description: find and convert tabs to spaces
         args: [--whitespaces-count, '2']
-        exclude: ^python/sedona/doc/make\.bat$|^python/sedona/doc/Makefile$|^spark/common/src/test/resources/.*$|^Makefile$|\.csv$|\.md$|\.tsv$
+        exclude: ^python/sedona/doc/make\.bat$|^spark/common/src/test/resources/.*$|(^|/)Makefile$|\.csv$|\.md$|\.tsv$
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
     hooks:


### PR DESCRIPTION
## Summary

CI broke on master after the most recent merge from apache:master. Three pre-commit hooks were failing:

- **forbid-tabs / remove-tabs**: the exclude pattern `^Makefile$` only matched the repo-root Makefile, so `databricks-tester/Makefile` was being rewritten to 2-space indentation.
- **editorconfig-checker**: followed up by flagging the now-space-indented `databricks-tester/Makefile` as needing tabs — a direct side-effect of the above.
- **zizmor `unpinned-uses`**: `databricks-tester.yml` and `snowflake-tester.yml` were the only workflow files still using floating `@v4`/`@v5` tags for `actions/*` uses; everything else already pins to SHAs.

### Changes

- `.pre-commit-config.yaml` — broaden `forbid-tabs` / `remove-tabs` exclude from `^Makefile$` to `(^|/)Makefile$` so any Makefile in the tree is exempt.
- `.github/workflows/databricks-tester.yml` — pin 9 `actions/*` uses to SHAs matching the SHAs already used in `docs.yml`, `java.yml`, etc.
- `.github/workflows/snowflake-tester.yml` — pin 3 `actions/*` uses to the same SHAs.

Verified locally: `pre-commit run forbid-tabs / remove-tabs / editorconfig-checker / zizmor --all-files` all pass.

## Test plan
- [ ] CI `pre-commit` and `pre-commit-manual` jobs pass.