### PR TITLE
Fix ST_OffsetCurve Snowflake V2 test failing with ST_AsText type error

### DIFF
--- a/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
+++ b/snowflake-tester/src/test/java/org/apache/sedona/snowflake/snowsql/TestFunctionsV2.java
@@ -720,8 +720,8 @@ public class TestFunctionsV2 extends TestBase {
   public void test_ST_OffsetCurve() {
     registerUDFV2("ST_OffsetCurve", String.class, double.class);
     verifySqlSingleRes(
-        "select sedona.ST_AsText(sedona.ST_OffsetCurve(ST_GeometryFromWKT('LINESTRING(0 0, 10 0)'), 5.0))",
-        "LINESTRING (0 5, 10 5)");
+        "select ST_AsText(sedona.ST_OffsetCurve(ST_GeometryFromWKT('LINESTRING(0 0, 10 0)'), 5.0))",
+        "LINESTRING(0 5,10 5)");
     registerUDFV2("ST_OffsetCurve", String.class, double.class, int.class);
     registerUDFV2("ST_NPoints", String.class);
     verifySqlSingleRes(


### PR DESCRIPTION
## What changes were proposed in this PR?

`TestFunctionsV2.test_ST_OffsetCurve` fails in the [Snowflake integration test run](https://github.com/wherobots/sedona-cloud-vendor-tester/actions/runs/25420494010/job/74561297657) with:

```
net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error: error line 1 at position 7
Invalid argument types for function 'ST_ASTEXT': (GEOMETRY)
```

The test calls `sedona.ST_AsText(...)` on the result of the V2 `ST_OffsetCurve`, which returns a native `GEOMETRY`. However, `TestBase.registerDependantUDFs()` only registers the V1 `sedona.ST_AsText(BINARY)` overload, and the test never registers the V2 `ST_AsText(GEOMETRY)` overload, so SQL compilation fails.

This PR switches the assertion to Snowflake's native `ST_AsText` (and its compact WKT output format), which is the convention used by all other tests in `TestFunctionsV2`.

Same fix submitted upstream: apache/sedona#3030

## How was this patch tested?

The `snowflake-tester` module compiles; the fix follows the exact pattern of the other passing V2 tests (e.g. `test_ST_AddPoint`, `test_ST_Boundary`). The integration suite on this PR's CI run will exercise it against the real Snowflake account.